### PR TITLE
Add more explicit check for pyspark library dependency.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [Please read through the Keep a Changelog (~5min)](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased] - y-m-d
-
+### Fixed
+- Fix issue which stripped non-pyspark libraries from a requirements file during deploys.
 
 ----
 

--- a/dbx/commands/deploy.py
+++ b/dbx/commands/deploy.py
@@ -221,7 +221,7 @@ def _delete_managed_libraries(packages: List[str]) -> List[str]:
 
     for package in packages:
 
-        if package.startswith("pyspark"):
+        if package == "pyspark" or package.startswith("pyspark="):
             dbx_echo("pyspark dependency deleted from the list of libraries, because it's a managed library")
         else:
             output_packages.append(package)

--- a/tests/unit/test_deploy.py
+++ b/tests/unit/test_deploy.py
@@ -236,7 +236,7 @@ class DeployTest(DbxTest):
 
             write_json(deployment_content, DEFAULT_DEPLOYMENT_FILE_PATH)
 
-            sample_requirements = "\n".join(["pyspark=3.0.0", "xgboost=0.6.0"])
+            sample_requirements = "\n".join(["pyspark=3.0.0", "xgboost=0.6.0", "pyspark3d"])
 
             pathlib.Path("runtime_requirements.txt").write_text(sample_requirements)
 
@@ -255,6 +255,11 @@ class DeployTest(DbxTest):
                         "test-branch",
                     ],
                 )
+
+                deleted_dependency_lines = [
+                    line for line in deploy_result.stdout.splitlines() if "pyspark dependency deleted" in line
+                ]
+                self.assertEqual(len(deleted_dependency_lines), 1)
 
                 self.assertEqual(deploy_result.exit_code, 0)
 


### PR DESCRIPTION
## Proposed changes

Our team internally uses a library called "pysparkblocks" which I wanted to deploy as a library dependency. When I deployed, dbx would remove that dependency because it was looking for any package starting with "pyspark." This adds a more explicit check for the pyspark library.

## Types of changes

What types of changes does your code introduce to dbx?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...

Closes #70 