### PR TITLE
fix one-word typo in documentation

### DIFF
--- a/dbx/commands/execute.py
+++ b/dbx/commands/execute.py
@@ -41,7 +41,7 @@ from dbx.utils.common import (
 
     The following set of actions will be done during execution:
 
-    1. If interactive cluster is stooped, it will be automatically started
+    1. If interactive cluster is stopped, it will be automatically started
     2. Package will be rebuilt from the source (can be disabled via :option:`--no-rebuild`)
     3. Job configuration will be taken from deployment file for given environment
     4. All referenced will be uploaded to the MLflow experiment


### PR DESCRIPTION
noticed while looking at the readthedocs.io page for dbx

## Proposed changes

Fix a one word typo in documentation, resolving issue #130.

## Types of changes

What types of changes does your code introduce to dbx?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation Update (if none of the other choices apply)

## Checklist

_Just docs changes. the below don't apply._

- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

