### PR TITLE
Fixed non posix path being used when on Windows

### DIFF
--- a/dbx/utils/common.py
+++ b/dbx/utils/common.py
@@ -421,7 +421,8 @@ class FileUploader:
             remote_path = self._artifact_uri / local_path.as_posix()
             self._uploaded_files[local_path] = remote_path
 
-        remote_path = str(remote_path).replace("dbfs:/", "/dbfs/") if as_fuse else str(remote_path)
+        remote_path = remote_path.as_posix()
+        remote_path = remote_path.replace("dbfs:/", "/dbfs/") if as_fuse else remote_path
         return remote_path
 
 


### PR DESCRIPTION
## Proposed changes
Provides resolution for https://github.com/databrickslabs/dbx/issues/154.
dbx deploy fails on windows
```
 Response from server:
 { 'error_code': 'INVALID_PARAMETER_VALUE',
  'message': 'Could not parse URI. Please double check your input.'}
```

Sample attribute in json causing issue
```
 "spark_python_task": {
                "python_file": "dbfs:\\Shared\\dbx\\projects\\sample_project\\0e95d32b79c34894a2e0d087d5935c21\\artifacts\\test.py"
            }
```

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules

## Further comments.
