### PR TITLE
[FEATURE][#184] Support auto-discovery of jinja templates

### DIFF
--- a/dbx/commands/deploy.py
+++ b/dbx/commands/deploy.py
@@ -251,7 +251,7 @@ def finalize_deployment_file_path(deployment_file: Optional[str]) -> str:
         return deployment_file
 
     else:
-        potential_extensions = ["json", "yml", "yaml"]
+        potential_extensions = ["json", "yml", "yaml", "json.j2", "yaml.j2", "yml.j2"]
 
         for ext in potential_extensions:
             candidate = pathlib.Path(f"conf/deployment.{ext}")

--- a/docs/source/jinja2_support.rst
+++ b/docs/source/jinja2_support.rst
@@ -1,10 +1,11 @@
 Jinja2 Support: Environment variables, logic and loops
 =============================================================
 
-Since version 0.4.0 :code:`dbx` supports `Jinja2 <https://jinja.palletsprojects.com/en/3.0.x/api/>`_ rendering for JSON and YAML based configurations.
+Since version 0.4.1 :code:`dbx` supports `Jinja2 <https://jinja.palletsprojects.com/en/3.0.x/api/>`_ rendering for JSON and YAML based configurations.
 This allows you to use environment variables in the deployment, add variable-based conditions, `Jinja filters <https://jinja.palletsprojects.com/en/3.0.x/templates/#filters>`_ and for loops to make your deployment more flexible for CI pipelines.
 
-To add Jinja2 support to your deployment file, please add postfix :code:`.j2` to the name of your deployment file, for example :code:`deployment.yml.j2`
+To add Jinja2 support to your deployment file, please add postfix :code:`.j2` to the name of your deployment file, for example :code:`deployment.yml.j2`.
+Deployment files stored at :code:`conf/deployment.(json|yml|yaml).j2`. will be auto-discovered.
 
 Please find examples on how to use Jinja2 templates below:
 

--- a/docs/source/quickstart.rst
+++ b/docs/source/quickstart.rst
@@ -52,11 +52,14 @@ This command will configure a project file in :code:`.dbx/project.json` file. Fe
 Preparing Deployment Config
 ---------------------------
 
-Next step would be to configure your deployment objects. To make this process easy and flexible, we support two options to define the configuration.
+Next step would be to configure your deployment objects. The main idea of the deployment file is to provide a flexible way to configure jobs with their dependencies.
+To make this process easy and flexible, we support two options to define the configuration.
 
-#. JSON: :code:`conf/deployment.json`: This is the default file which will be picked up automatically.
-#. YAML: :code:`conf/deployment.yaml`: To use [ yaml | yml ] you will need to explicitly specify the file using the option :code:`--deployment-file=./conf/deployment.yaml`
+#. JSON: :code:`conf/deployment.json`
+#. YAML: :code:`conf/deployment.(yml|yaml)`
 
+If the above options are located relative to the project root directory they will be auto-discovered, else you will need to explicitly specify the file to :code:`dbx deploy` using the option :code:`--deployment-file=./path/to/file.(json|yml|yaml)`.
+The :code:`--deployment-file` option also allows you to use multiple different deployment files.
 
 .. note::
 
@@ -69,13 +72,14 @@ Next step would be to configure your deployment objects. To make this process ea
 
     :code:`dbx` supports passing environment variables into both JSON and YAML based deployment files. Please read more about this functionality :doc:`here <environment_variables>`.
 
+.. note::
+
+    Since version 0.4.1 :code:`dbx` :doc:`supports Jinja2 <jinja2_support>` rendering for JSON and YAML based configurations.
+
 
 JSON
 ****
 
-By default, deployment configuration is stored in :code:`conf/deployment.json`.
-The main idea of the deployment file is to provide a flexible way to configure job with it's dependencies.
-You can use multiple different deployment files, providing the filename as an argument to :code:`dbx deploy` via :code:`--deployment-file=/path/to/file.json` option.
 Here are some samples of deployment files for different cloud providers:
 
 .. tabs::
@@ -127,9 +131,6 @@ any local files can be referenced and will be uploaded to dbfs in a versioned wa
 
 YAML
 ****
-
-If you want to use yaml, you will have to specify the file using :code:`--deployment-file=/path/to/file.yaml` option
-available on the :code:`dbx deploy` or :code:`dbx execute` commands.
 
 You can define re-usable definitions in yaml. Here is an example yaml and its json equivalent:
 

--- a/docs/source/templates/python_basic.rst
+++ b/docs/source/templates/python_basic.rst
@@ -191,7 +191,7 @@ Use this command to execute a specific job on interactive cluster:
 
 .. code-block::
 
-    dbx execute --deployment-file=conf/deployment.yml --job=<job-name> --cluster-name=<cluster-name>
+    dbx execute --job=<job-name> --cluster-name=<cluster-name>
 
 Now, if you would like to launch your job on an automated cluster, you probably would like to configure some specific cluster properties, such as size, environment etc.
 To do this, please take a look at the :code:`conf/deployment.yml` file. In general, this file follows the Databricks API structures, but it has some additional features, described through this documentation.
@@ -201,7 +201,7 @@ Instead of this, we're going to perform something called jobless deployment, by 
 
 .. code-block::
 
-    dbx deploy --deployment-file=conf/deployment.yml --jobs=<job-name> --files-only
+    dbx deploy --jobs=<job-name> --files-only
 
 Now the job can be launched in a run submit mode:
 


### PR DESCRIPTION
## Proposed changes

Auto-discovery would be supported for deployment files ending in .j2 and matching auto-discovery path prefix: conf/deployment.(json.j2|yaml.j2|yml.j2)

Described in more detail by #183.

## Types of changes

What types of changes does your code introduce to dbx?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation Update (if none of the other choices apply)
