### PR TITLE
Support includes in jinja2 templates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased] - YYYY-MM-DD
 
+- Support including jinja templates from subpaths of the current working directory
 - Refactor the configuration code
 - Refactor the JSON-related code
 - Add `--path` and `--checkout` options to the `dbx init`

--- a/dbx/utils/common.py
+++ b/dbx/utils/common.py
@@ -132,7 +132,7 @@ class Jinja2DeploymentConfig(AbstractDeploymentConfig):
         # jinja are not actual filesystem paths, but often have a one-to-one mapping.
         # To retain platform independence, we replace whatever the operating system's
         # preferred separator is with a forward slash to keep compatibility with jinja.
-        template_path = os.path.relpath(self._path, start=root_dir).replace(os.sep, '/')
+        template_path = os.path.relpath(self._path, start=root_dir).replace(os.sep, "/")
         # We render templates with an environment from the root directory so
         # that other template includes can be processed
         j2_env = jinja2.Environment(loader=jinja2.FileSystemLoader(root_dir))

--- a/tests/deployment-configs/includes/cluster-test.json.j2
+++ b/tests/deployment-configs/includes/cluster-test.json.j2
@@ -1,0 +1,9 @@
+{
+    "spark_version": "7.3.x-cpu-ml-scala2.12",
+    "node_type_id": "some-node-type",
+    "aws_attributes": {
+        "first_on_demand": 0,
+        "availability": "SPOT"
+    },
+    "num_workers": 2
+}

--- a/tests/deployment-configs/nested-configs/09-jinja-include.json.j2
+++ b/tests/deployment-configs/nested-configs/09-jinja-include.json.j2
@@ -1,0 +1,15 @@
+{
+    "default": {
+        "jobs": [
+            {
+                "name": "your-job-name",
+                "new_cluster": {% include 'tests/deployment-configs/includes/cluster-test.json.j2' %},
+                "libraries": [],
+                "max_retries": 0,
+                "spark_python_task": {
+                    "python_file": "tests/deployment-configs/placeholder_1.py"
+                }
+            }
+        ]
+    }
+}

--- a/tests/unit/test_common.py
+++ b/tests/unit/test_common.py
@@ -263,6 +263,18 @@ class CommonUnitTest(unittest.TestCase):
         self.assertEqual(json_emails, None)
         self.assertEqual(yaml_emails, None)
 
+    def test_jinja_with_include(self):
+        """Ensure that templates from other directories can be included.
+
+        In this test, the top level jinja template includes another template which describes the
+        cluster.
+        """
+        json_j2_file = format_path("../deployment-configs/nested-configs/09-jinja-include.json.j2")
+        json_default_envs = get_deployment_config(json_j2_file).get_environment("default")
+        json_node_type = json_default_envs.get("jobs")[0].get("new_cluster").get("node_type_id")
+
+        self.assertEqual(json_node_type, "some-node-type")
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Proposed changes
Prior to this change, the jinja2 `include` directive only allows inclusion of files that are "below" the parent directory of the template file; e.g. if you use `/path/to/my_template.json.j2` then only templates in a path with prefix `/path/to` can be included. This restricts ability to organize files within a repo and use `include` as an abstraction.

This change sets the root directory as the jinja2 rendering environment. This allows templates to include other files from the directory (rather than being limited to only the parent directory of the specified template).

## Types of changes

What types of changes does your code introduce to dbx?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Further comments

Briefly discussed in #191 .

Added test initially fails with:

```
FAILED tests/unit/test_common.py::CommonUnitTest::test_jinja_with_include - jinja2.exceptions.TemplateNotFound: tests/deployment-configs/includes/cluster-test.json.j2
```

and succeeds after the slight implementation changes in this PR.

Note: at a first look, it may be desirable to add a similar test for inclusions with yaml-based templates. However, because yaml is indent-sensitive, and jinja2 includes do not satisfy any constraints of indentation, I wasn't sure of what a realistic use case was for this (i.e. the yaml version of the test I have would not produce valid yaml from jinja2 rendering).
