### PR TITLE
Linting fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,7 @@ PYTHON_VERSION=3.7.5
 VENV_NAME=.venv
 VENV_DIR=${VENV_NAME}
 PYTHON=${VENV_DIR}/bin/python
+RSTCHECK=${VENV_DIR}/bin/rstcheck
 SPHINX_AUTOBUILD=${VENV_DIR}/bin/sphinx-autobuild
 SPHINX_BUILD=${VENV_DIR}/bin/sphinx-build
 ##############################################################################
@@ -175,7 +176,7 @@ lint: ## Run the lint and checks
 	@echo "${YELLOW}Linting code:${NORMAL}"
 	@make helper-line
 	$(PYTHON) -m prospector --profile prospector.yaml
-	$(PYTHON) -m rstcheck README.rst
+	$(RSTCHECK) README.rst
 	@make check
 
 check: ## Run black checks

--- a/Makefile
+++ b/Makefile
@@ -183,15 +183,13 @@ check: ## Run black checks
 	@echo ""
 	@echo "${YELLOW}Check code with black:${NORMAL}"
 	@make helper-line
-	$(PYTHON) -m black --check ./dbx
-	$(PYTHON) -m black --check ./tests
+	$(PYTHON) -m black --check .
 
 fix: ## fix the code with black formatter.
 	@echo ""
 	@echo "${YELLOW}Fixing code with black:${NORMAL}"
 	@make helper-line
-	$(PYTHON) -m black ./dbx
-	$(PYTHON) -m black ./tests
+	$(PYTHON) -m black .
 
 ##############################################################################
 

--- a/prospector.yaml
+++ b/prospector.yaml
@@ -29,7 +29,9 @@ pylint:
     - raise-missing-from # pretty strange requirement with acquaint logic
 
 pep8:
-  disable: W293 # disabled because we have newlines in docstrings
+  # W293: disabled because we have newlines in docstrings
+  # E203: disabled because pep8 and black disagree on whitespace before colon in some cases
+  disable: W293,E203
 
 mccabe:
   disable:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,6 +5,7 @@ exclude = '''
 /(
   | dbx/templates/projects
   | build
+  | .venv
 )/
 
 '''


### PR DESCRIPTION
## Proposed changes

Fixes for linting issues #234 #235 #236

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Further comments

`make lint` failed when I tried running it because rstcheck can't be run as a module.  Instead it now runs the executable directly from the bin directory, just like `python`.

`setup.py` black issues weren't caught locally because black wasn't running on it.  I've updated the command in `Makefile` to be consistent with the github workflow.  I've also added `.venv` to the ignore list, otherwise black runs on it.

I noticed for a code snippet like `x[i + 1 :]`, black and pep8 disagree on whether there should be whitespace before the colon.  To address this I've updated prospector's config to ignore `E203` to go with black's choice.
