### PR TITLE
Add sync commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Refactor the JSON-related code
 - Add `--path` and `--checkout` options to the `dbx init`
 - Change the format of the `python_basic` to use pytest
+- Add `sync repo` and `sync dbfs` commands for syncing local files to Databricks and watching for changes.
 ----
 > Unreleased changes must be tracked above this line.
 > When releasing, Copy the changelog to below this line, with proper version and date.

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ SHELL=/bin/bash
 
 
 ##############################################################################
-PYTHON_VERSION=3.7.5
+PYTHON_VERSION=3.8.13
 VENV_NAME=.venv
 VENV_DIR=${VENV_NAME}
 PYTHON=${VENV_DIR}/bin/python

--- a/dbx/cli.py
+++ b/dbx/cli.py
@@ -7,6 +7,7 @@ from dbx.commands.execute import execute
 from dbx.commands.launch import launch
 from dbx.commands.datafactory import datafactory
 from dbx.commands.init import init
+from dbx.commands.sync import cli as sync_cli
 
 
 @click.group(context_settings=CONTEXT_SETTINGS)
@@ -21,6 +22,7 @@ cli.add_command(launch, name="launch")
 cli.add_command(execute, name="execute")
 cli.add_command(datafactory, name="datafactory")
 cli.add_command(init, name="init")
+cli.add_command(sync_cli, name="sync")
 
 if __name__ == "__main__":
     cli()

--- a/dbx/commands/sync.py
+++ b/dbx/commands/sync.py
@@ -190,6 +190,14 @@ def handle_source(source: str = None) -> str:
 
 
 def get_user_name(config: DatabricksConfig) -> str:
+    """Gets the name of the user according to the Databricks API using the config for authorization.
+
+    Args:
+        config (DatabricksConfig): config to use to get user info
+
+    Returns:
+        str: name of user
+    """
     user_info = get_user(config)
     return user_info.get("userName")
 

--- a/dbx/commands/sync.py
+++ b/dbx/commands/sync.py
@@ -167,18 +167,6 @@ def subdirs_to_patterns(source: str, subdirs: List[str]) -> List[str]:
     return patterns
 
 
-@cli.command()
-@click.option("--profile", type=str, help="The databricks-cli profile to use for accessing the API token")
-def check(profile: str):
-    """
-    Check if configuration for Databricks is valid.
-    """
-    # This will fail if the API token doesn't work.
-    get_databricks_config(profile)
-
-    click.echo(click.style("Databricks API token is properly configured and working", fg="green"))
-
-
 def handle_source(source: str = None) -> str:
     """Determine the source directory to sync from.  If the source directory is not specified
     then it will check if the current directory has a .git subdirectory, implying that the current

--- a/dbx/commands/sync.py
+++ b/dbx/commands/sync.py
@@ -33,7 +33,7 @@ def cli():
     """
     Sync local files to Databricks and watch for changes.
     """
-    pass
+    pass  # pragma: no cover
 
 
 def create_path_matcher(*, source: str, includes: List[str], excludes: List[str]) -> PathMatcher:
@@ -103,7 +103,7 @@ def main_loop(
     # Windows by default uses a different event loop policy which results in "Event loop is closed" errors
     # for some reason.
     if platform.system() == "Windows":
-        asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())
+        asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())  # pragma: no cover
 
     dbx_echo("Starting initial copy")
 

--- a/dbx/commands/sync.py
+++ b/dbx/commands/sync.py
@@ -1,0 +1,384 @@
+import asyncio
+import os
+import platform
+import time
+from getpass import getuser
+from pathlib import Path
+from typing import List
+
+import click
+
+from dbx.sync.clients import BaseClient, DBFSClient, ReposClient
+from dbx.sync.config import get_databricks_config
+from dbx.sync.event_handler import file_watcher
+from dbx.sync.path_matcher import PathMatcher
+from dbx.sync import DeleteUnmatchedOption, RemoteSyncer
+from dbx.utils import dbx_echo
+
+# Patterns for files that are ignored by default.  There don't seem to be any reasonable scenarios where someone
+# would want to sync these, so we don't make this configurable.
+DEFAULT_IGNORES = [".git/", ".dbx", "*.isorted"]
+
+
+def validate_allow_unmatched(ctx, param, value):  # noqa
+    if value is None:
+        return DeleteUnmatchedOption.UNSPECIFIED_DELETE_UNMATCHED
+    if value:
+        return DeleteUnmatchedOption.ALLOW_DELETE_UNMATCHED
+    return DeleteUnmatchedOption.DISALLOW_DELETE_UNMATCHED
+
+
+@click.group()
+def cli():
+    """
+    Sync local files to Databricks and watch for changes.
+    """
+    pass
+
+
+def create_path_matcher(*, source: str, includes: List[str], excludes: List[str]) -> PathMatcher:
+    """Set up a pattern matcher that is used to ignores changes to files we don't want synced.
+
+    Args:
+        source (str): root directory includes and excludes are relative to
+        includes (List[str]): Patterns to include.
+        excludes (List[str]): Patterns to exclude.
+
+    Returns:
+        PathMatcher: matcher for matching files
+    """
+
+    ignores = list(DEFAULT_IGNORES)
+
+    gitignore_path = os.path.join(source, ".gitignore")
+    if os.path.exists(gitignore_path):
+        dbx_echo(f"Ignoring patterns from {gitignore_path}")
+        with open(gitignore_path, encoding="utf-8") as f:
+            ignores.extend(f.readlines())
+
+    if not includes:
+        includes = []
+        syncinclude_path = os.path.join(source, ".syncinclude")
+        if os.path.exists(syncinclude_path):
+            dbx_echo(f"Including patterns from {syncinclude_path}")
+            with open(syncinclude_path, encoding="utf-8") as f:
+                includes.extend(f.readlines())
+
+    if excludes:
+        ignores.extend(excludes)
+
+    return PathMatcher(root_dir=source, ignores=ignores, includes=includes)
+
+
+class StopIncrementalCopy(Exception):
+    pass
+
+
+def main_loop(
+    *,
+    source: str,
+    client: BaseClient,
+    full_sync: bool,
+    dry_run: bool,
+    includes: List[str],
+    excludes: List[str],
+    watch: bool,
+    sleep_interval: float = 0.25,
+    delete_unmatched_option: DeleteUnmatchedOption = DeleteUnmatchedOption.UNSPECIFIED_DELETE_UNMATCHED,
+):
+    """
+    Performs the initial sync from the source directory and then watches for changes, performing
+    an incremental sync whenever changes are detected.
+    """
+
+    matcher = create_path_matcher(source=source, includes=includes, excludes=excludes)
+
+    syncer = RemoteSyncer(
+        client=client,
+        source=source,
+        includes=includes,
+        excludes=excludes,
+        dry_run=dry_run,
+        full_sync=full_sync,
+        matcher=matcher,
+        delete_unmatched_option=delete_unmatched_option,
+    )
+
+    # Windows by default uses a different event loop policy which results in "Event loop is closed" errors
+    # for some reason.
+    if platform.system() == "Windows":
+        asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())
+
+    dbx_echo("Starting initial copy")
+
+    # Run the incremental copy and record how many operations were performed or would have been
+    # performed (if in dry run mode).  An operation usually translates to an API call, such as
+    # create a directory, put a file, etc.
+    op_count = asyncio.run(syncer.incremental_copy())
+
+    if not op_count:
+        dbx_echo("No changes found during initial copy")
+
+    if dry_run:
+        dbx_echo("This was a dry run.  Exiting now.")
+    elif watch:
+        dbx_echo("Done. Watching for changes...")
+
+        with file_watcher(source=source, matcher=matcher) as event_handler:
+            while True:
+                while True:
+                    events = event_handler.get_events()
+                    if events:
+                        break
+                    time.sleep(sleep_interval)
+
+                try:
+                    op_count = asyncio.run(syncer.incremental_copy())
+                except StopIncrementalCopy:
+                    # simple way to enable unit testing to break out of loop
+                    break
+
+                if op_count > 0:
+                    dbx_echo("Done")
+
+
+def subdirs_to_patterns(source: str, subdirs: List[str]) -> List[str]:
+    """Converts a list of subdirectories under a source directory to a
+    list of gitignore-style patterns that match those directories.
+
+    Args:
+        source (str): source directory these subdirs exist under
+        subdirs (List[str]): subdirectories to create patterns for
+
+    Raises:
+        click.BadArgumentUsage: directory doesn't exist
+
+    Returns:
+        List[str]: list of patterns matching subdirs
+    """
+    patterns = []
+    for subdir in subdirs:
+        full_subdir = os.path.join(source, subdir)
+        if not os.path.exists(full_subdir):
+            raise click.BadArgumentUsage(f"Path {full_subdir} does not exist")
+        subdir = Path(subdir).as_posix()
+        patterns.append(f"/{subdir}/")
+    return patterns
+
+
+@cli.command()
+@click.option("--profile", type=str, help="The databricks-cli profile to use for accessing the API token")
+def check(profile: str):
+    """
+    Check if configuration for Databricks is valid.
+    """
+    # This will fail if the API token doesn't work.
+    get_databricks_config(profile)
+
+    click.echo(click.style("Databricks API token is properly configured and working", fg="green"))
+
+
+def handle_source(source: str = None) -> str:
+    """Determine the source directory to sync from.  If the source directory is not specified
+    then it will check if the current directory has a .git subdirectory, implying that the current
+    directory should be the source.
+
+    Args:
+        source (str): source directory to use, or None to try automatically determining
+
+    Raises:
+        click.UsageError: When the source directory is unspecified and can't be automatically determined.
+
+    Returns:
+        str: source directory to sync from
+    """
+    if not source:
+        # If this is being run from the base of a git repo, then they probably want to use
+        # the repo as the source.
+        if os.path.exists(".git"):
+            source = "."
+        else:
+            raise click.UsageError("Must specify source directory using --source")
+
+    source = os.path.abspath(source)
+
+    dbx_echo(f"Syncing from {source}")
+
+    return source
+
+
+def common_options(f):
+    f = click.option("--profile", type=str, help="The databricks-cli profile to use for accessing the API token")(f)
+    f = click.option("--source", "-s", type=click.Path(exists=True, dir_okay=True, file_okay=False), required=False)(f)
+    f = click.option("--full-sync", is_flag=True, help="Copy everything from the source on the initial sync")(f)
+    f = click.option("--dry-run", is_flag=True)(f)
+    f = click.option(
+        "--include",
+        "-i",
+        "include_dirs",
+        multiple=True,
+        type=str,
+        required=False,
+        help="Directory under the source directory to sync",
+    )(f)
+    f = click.option("--exclude", "-e", "exclude_dirs", type=str, multiple=True)(f)
+    f = click.option(
+        "--include-pattern",
+        "-ip",
+        "include_patterns",
+        multiple=True,
+        type=str,
+        required=False,
+        help="Pattern under the source directory to sync",
+    )(f)
+    f = click.option(
+        "--allow-delete-unmatched/--disallow-delete-unmatched",
+        "delete_unmatched_option",
+        callback=validate_allow_unmatched,
+        type=bool,
+        default=None,
+        help="How to handle files/directories that would be deleted in remote because they don't match a filter",
+    )(f)
+    f = click.option("--exclude-pattern", "-ep", "exclude_patterns", type=str, multiple=True)(f)
+    f = click.option("--watch/--no-watch", is_flag=True, default=True)(f)
+    return f
+
+
+@cli.command()
+@common_options
+@click.option("--dest", "-d", "dest_path", type=str, required=False)
+@click.option("--user", "-u", "user_name", type=str)
+def dbfs(
+    user_name: str,
+    source: str,
+    full_sync: bool,
+    dry_run: bool,
+    include_dirs: List[str],
+    dest_path: str,
+    exclude_dirs: List[str],
+    profile: str,
+    watch: bool,
+    include_patterns: List[str],
+    exclude_patterns: List[str],
+    delete_unmatched_option: DeleteUnmatchedOption,
+):
+    """
+    Syncs from source directory to DBFS.
+
+    By default this syncs to a destination path under /tmp/users/<username>.  The destination path is derived
+    from the base name of the source path.  So syncing from /foo/bar would use a full destination path of
+    /tmp/users/<username>/bar.  The destination path can be changed from the default base name using --dest.
+    """
+
+    # watch defaults to true, so to make it easy to just add --dry-run without having to add --no-watch,
+    # we'll set watch to false here.
+    if dry_run:
+        watch = False
+
+    config = get_databricks_config(profile)
+
+    source = handle_source(source)
+
+    include_patterns = list(include_patterns) or []
+    exclude_patterns = list(exclude_patterns) or []
+
+    include_patterns.extend(subdirs_to_patterns(source, include_dirs))
+    exclude_patterns.extend(subdirs_to_patterns(source, exclude_dirs))
+
+    # To make the tool easier to use, pick a reasonable destination path under /tmp if one is not specified that is
+    # highly unlikely to overwrite anything important.
+    if not dest_path:
+        source_base_name = os.path.basename(source)
+        if not source_base_name:
+            raise click.UsageError("Destination path can't be determined.  Please specify with --dest.")
+
+        if not user_name:
+            user_name = getuser()
+
+        if not user_name:
+            raise click.UsageError(
+                "Destination path can't be automatically determined because the user is not known. "
+                "Please either specify the user with --user or provide the destination path with --dest."
+            )
+
+        dest_path = f"/tmp/users/{user_name}/{source_base_name}"
+
+    # Syncing to root is probably a bad idea.
+    if dest_path == "/":
+        raise click.BadParameter("Destination cannot be the root path.  Please specify a subdirectory.")
+
+    client = DBFSClient(base_path=dest_path, config=config)
+
+    main_loop(
+        source=source,
+        client=client,
+        full_sync=full_sync,
+        dry_run=dry_run,
+        includes=include_patterns,
+        excludes=exclude_patterns,
+        watch=watch,
+        delete_unmatched_option=delete_unmatched_option,
+    )
+
+
+@cli.command()
+@common_options
+@click.option("--dest-repo", "-d", type=str, help="REPO in the destination path /Repos/USER/REPO", required=True)
+@click.option(
+    "--user",
+    "-u",
+    "user",
+    type=str,
+    help="USER in the destination path /Repos/USER/REPO",
+    default=os.environ.get("DBX_SYNC_REPO_USER"),
+)
+def repo(
+    user: str,
+    source: str,
+    full_sync: bool,
+    dry_run: bool,
+    include_dirs: List[str],
+    dest_repo: str,
+    exclude_dirs: List[str],
+    profile: str,
+    watch: bool,
+    include_patterns: List[str],
+    exclude_patterns: List[str],
+    delete_unmatched_option: DeleteUnmatchedOption,
+):
+    """
+    Syncs from source directory to a repo in Databricks.
+
+    This can sync to a destination path under /Repos/<user>/<repo> using --dest-repo and --user.
+    """
+
+    if not user:
+        raise click.UsageError("Repo user must be specified with --user")
+
+    # watch defaults to true, so to make it easy to just add --dry-run without having to add --no-watch,
+    # we'll set watch to false here.
+    if dry_run:
+        watch = False
+
+    config = get_databricks_config(profile)
+
+    source = handle_source(source)
+
+    include_patterns = list(include_patterns) or []
+    exclude_patterns = list(exclude_patterns) or []
+
+    include_patterns.extend(subdirs_to_patterns(source, include_dirs))
+    exclude_patterns.extend(subdirs_to_patterns(source, exclude_dirs))
+
+    client = ReposClient(user=user, repo_name=dest_repo, config=config)
+
+    main_loop(
+        source=source,
+        client=client,
+        full_sync=full_sync,
+        dry_run=dry_run,
+        includes=include_patterns,
+        excludes=exclude_patterns,
+        watch=watch,
+        delete_unmatched_option=delete_unmatched_option,
+    )

--- a/dbx/commands/sync.py
+++ b/dbx/commands/sync.py
@@ -1,6 +1,4 @@
-import asyncio
 import os
-import platform
 import time
 from pathlib import Path
 from typing import List
@@ -100,17 +98,12 @@ def main_loop(
         delete_unmatched_option=delete_unmatched_option,
     )
 
-    # Windows by default uses a different event loop policy which results in "Event loop is closed" errors
-    # for some reason.
-    if platform.system() == "Windows":
-        asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())  # pragma: no cover
-
     dbx_echo("Starting initial copy")
 
     # Run the incremental copy and record how many operations were performed or would have been
     # performed (if in dry run mode).  An operation usually translates to an API call, such as
     # create a directory, put a file, etc.
-    op_count = asyncio.run(syncer.incremental_copy())
+    op_count = syncer.incremental_copy()
 
     if not op_count:
         dbx_echo("No changes found during initial copy")
@@ -134,7 +127,7 @@ def main_loop(
                     time.sleep(sleep_interval)
 
                 # Run incremental copy to sync over changes since the last sync.
-                op_count = asyncio.run(syncer.incremental_copy())
+                op_count = syncer.incremental_copy()
 
                 # simple way to enable unit testing to break out of loop
                 if op_count < 0:

--- a/dbx/sync/__init__.py
+++ b/dbx/sync/__init__.py
@@ -32,6 +32,8 @@ def is_dir_ancestor(possible_ancestor: str, path: str) -> str:
 def get_relative_path(ancestor: str, path: str):
     ancestor = str(Path(ancestor))
     path = str(Path(path))
+    if ancestor == path:
+        raise ValueError(f"ancestor and path are the same: {path}")
     if not is_dir_ancestor(ancestor, path):
         raise ValueError(f"{ancestor} is not an ancestor of {path}")
     return Path(path[len(ancestor) + 1 :]).as_posix()

--- a/dbx/sync/__init__.py
+++ b/dbx/sync/__init__.py
@@ -1,0 +1,451 @@
+import asyncio
+import hashlib
+import os
+import pickle
+from enum import Enum
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from typing import List, Union
+
+import aiohttp
+import click
+from watchdog.utils.dirsnapshot import DirectorySnapshot, EmptyDirectorySnapshot
+
+from dbx.utils import dbx_echo
+
+from .clients import BaseClient
+from .constants import DBX_SYNC_DIR
+from .path_matcher import PathMatcher
+from .snapshot import SnapshotDiff, compute_snapshot_diff
+
+
+class DeleteUnmatchedOption(Enum):
+    ALLOW_DELETE_UNMATCHED = 1
+    DISALLOW_DELETE_UNMATCHED = 2
+    UNSPECIFIED_DELETE_UNMATCHED = 3
+
+
+def is_dir_ancestor(possible_ancestor: str, path: str) -> str:
+    return possible_ancestor == os.path.commonpath([possible_ancestor, path])
+
+
+def get_relative_path(ancestor: str, path: str):
+    ancestor = str(Path(ancestor))
+    path = str(Path(path))
+    if not is_dir_ancestor(ancestor, path):
+        raise ValueError(f"{ancestor} is not an ancestor of {path}")
+    return Path(path[len(ancestor) + 1 :]).as_posix()
+
+
+def with_depth(d: str) -> int:
+    """Compute the depth of a directory and prepend it as a tuple.
+    This is used to sort directories by depth.
+
+    Args:
+        d (str): directory
+
+    Returns:
+        int: depth of directory
+    """
+    return (len(Path(d).as_posix().split("/")), d)
+
+
+def get_snapshot_name(client: BaseClient) -> str:
+    """Gets the path that will be used to save sync snapshots for the given client.
+    Each client writes to a particular destination type, like repos or dbfs, and uses
+    a particular base path.  These together determine the name of the state file.
+
+    Args:
+        client (BaseClient): client used for syncing
+
+    Returns:
+        str: name of the state file
+    """
+    dir_name = client.base_path.split("/")[-1]
+    base_path_hash = hashlib.md5(client.base_path.encode("utf-8")).hexdigest()
+    return f"{dir_name}-{client.name}-{base_path_hash}"
+
+
+class RemoteSyncer:
+    def __init__(
+        self,
+        *,
+        client: BaseClient,
+        source: str,
+        dry_run: bool,
+        matcher: PathMatcher,
+        includes: List[str],
+        excludes: List[str],
+        full_sync: bool = False,
+        max_parallel: int = 4,
+        state_dir: Union[Path, str] = DBX_SYNC_DIR,
+        delete_unmatched_option: DeleteUnmatchedOption = DeleteUnmatchedOption.UNSPECIFIED_DELETE_UNMATCHED,
+    ):
+        # State directory should be relative to the directory we're syncing from.  Usually this will
+        # be the same directory the tool is run from, but you can specify a different source directory.
+        state_dir = Path(source) / Path(state_dir)
+
+        self.includes = includes
+        self.excludes = excludes
+        self.client = client
+        self.source = source
+        self.state_dir = state_dir
+        self.full_sync = full_sync
+        self.dry_run = dry_run
+        self.max_parallel = max_parallel
+        self.is_first_sync = True
+        self.tempdir = TemporaryDirectory().name  # noqa
+        self.matcher = matcher
+        self.snapshot_path = os.path.join(state_dir, get_snapshot_name(client))
+        self.last_snapshot = None
+        self.delete_unmatched_option = delete_unmatched_option
+
+        if not os.path.exists(state_dir):
+            os.makedirs(state_dir)
+
+        if self.dry_run:
+            dbx_echo("Performing a dry run")
+
+        if self.full_sync:
+            dbx_echo("Performing a full sync")
+
+    async def _apply_dirs_created(self, diff: SnapshotDiff, session: aiohttp.ClientSession) -> None:
+        op_count = 0
+
+        # Sort dirs by depth so we can create directories in parallel as much as possible.
+        dirs_created = [with_depth(d) for d in diff.dirs_created]
+        dirs_created = sorted(dirs_created, key=lambda p: p[0])
+
+        curr_depth = None
+        tasks = []
+        for depth, path in dirs_created:
+            op_count += 1
+            if not self.dry_run:
+
+                if curr_depth is None:
+                    curr_depth = depth
+
+                # When we're about to create a directory at the next depth, wait for any existing
+                # directory creations to complete.  We want to make sure parents are created before children.
+                if depth > curr_depth and tasks:
+                    await asyncio.gather(*tasks)
+                    curr_depth = depth
+                    tasks = []
+
+                tasks.append(self.client.mkdirs(get_relative_path(self.source, path), session=session))
+
+            else:
+                dbx_echo(f"(noop) Dir created: {path}")
+        if tasks:
+            await asyncio.gather(*tasks)
+        return op_count
+
+    async def _apply_dirs_deleted(
+        self, diff: SnapshotDiff, session: aiohttp.ClientSession, deleted_dirs: List[str]
+    ) -> None:
+        op_count = 0
+
+        # Sort dirs by depth so we can delete the higher level directories first.  Because deletes are
+        # recursive, this will probably save us some work by eliminating deeper directories that
+        # need to be deleted.
+        dirs_deleted = [with_depth(d) for d in diff.dirs_deleted]
+        dirs_deleted = sorted(dirs_deleted, key=lambda p: p[0])
+
+        for _, path in sorted(dirs_deleted):
+            # If an ancestor has been deleted, then we don't need to delete because it would have already
+            # been deleted.
+            if not any(is_dir_ancestor(deleted_path, path) for deleted_path in deleted_dirs):
+                op_count += 1
+                if not self.dry_run:
+                    await self.client.delete(get_relative_path(self.source, path), session=session, recursive=True)
+                    deleted_dirs.append(path)
+                else:
+                    dbx_echo(f"(noop) Dir deleted: {path}")
+        return op_count
+
+    async def _apply_files_created(self, diff: SnapshotDiff, session: aiohttp.ClientSession) -> None:
+        tasks = []
+        op_count = 0
+        for path in sorted(diff.files_created):
+            op_count += 1
+            if not self.dry_run:
+                # Files can be created in parallel.
+                tasks.append(self.client.put(get_relative_path(self.source, path), path, session=session))
+            else:
+                dbx_echo(f"(noop) File created: {path}")
+        if tasks:
+            await asyncio.gather(*tasks)
+        return op_count
+
+    async def _apply_files_deleted(
+        self, diff: SnapshotDiff, session: aiohttp.ClientSession, deleted_dirs: List[str]
+    ) -> None:
+        tasks = []
+        op_count = 0
+        for path in sorted(diff.files_deleted):
+            # No need to delete a file if an ancestor directory has already been deleted, as deletes
+            # are recursive.
+            if not any(is_dir_ancestor(deleted_path, path) for deleted_path in deleted_dirs):
+                op_count += 1
+                if not self.dry_run:
+                    # Files can be deleted in parallel.
+                    tasks.append(self.client.delete(get_relative_path(self.source, path), session=session))
+                else:
+                    dbx_echo(f"(noop) File deleted: {path}")
+        if tasks:
+            await asyncio.gather(*tasks)
+        return op_count
+
+    async def _apply_files_modified(self, diff: SnapshotDiff, session: aiohttp.ClientSession) -> None:
+        tasks = []
+        op_count = 0
+        for path in sorted(diff.files_modified):
+            op_count += 1
+            if not self.dry_run:
+                # Files can be created in parallel.
+                tasks.append(self.client.put(get_relative_path(self.source, path), path, session=session))
+            else:
+                dbx_echo(f"(noop) File modified: {path}")
+        if tasks:
+            await asyncio.gather(*tasks)
+        return op_count
+
+    async def _apply_snapshot_diff(self, diff: SnapshotDiff, session: aiohttp.ClientSession) -> int:
+        op_count = 0
+
+        # Collects directories deleted while applying this diff.  Since we perform recursive deletes, we can
+        # avoid making some delete operations if an ancestor has already been deleted.
+        deleted_dirs = []
+
+        op_count += await self._apply_dirs_deleted(diff, session, deleted_dirs)
+        op_count += await self._apply_dirs_created(diff, session)
+        op_count += await self._apply_files_created(diff, session)
+        op_count += await self._apply_files_deleted(diff, session, deleted_dirs)
+        op_count += await self._apply_files_modified(diff, session)
+
+        return op_count
+
+    def _remove_unmatched_deletes(self, diff: SnapshotDiff) -> SnapshotDiff:
+        """Creates a new snapshot diff where file and directory deletes that don't match the current
+        filters are removed.  If this diff is applied then these files/directories won't be deleted
+        in the remote location.
+
+        Args:
+            diff (SnapshotDiff): diff to update
+
+        Returns:
+            SnapshotDiff: new diff with unmatched deletes removed
+        """
+
+        return SnapshotDiff(
+            files_created=diff.files_created,
+            files_modified=diff.files_modified,
+            dirs_created=diff.dirs_created,
+            dirs_deleted=[d for d in diff.dirs_deleted if self.matcher.match(d, is_directory=True)],
+            files_deleted=[f for f in diff.files_deleted if self.matcher.match(f, is_directory=False)],
+        )
+
+    async def _dryrun_snapshot_diff_unmatched_deletes(self, diff: SnapshotDiff) -> int:
+        """Performs a dry run on only the unmatched file and directory deletes.  These are paths that would
+        not be matched by the current filters.  This dry run provides useful logging to the user to understand
+        what is happening.
+
+        Unmatched deletes happen when the user switches the include/exclude options between different runs.
+        This results in files/directories being removed in the remote that don't match the filters, which may
+        or may not be what the user wants.
+
+        Args:
+            diff (SnapshotDiff): diff to perform dry run with
+
+        Returns:
+            int: number of operations that would have been performed on unmatched deletes
+        """
+        prev_dry_run = self.dry_run
+        try:
+            self.dry_run = True
+
+            # Modify the diff to only include files and directories being deleted that don't match the current
+            # filter.  This implies that these are only being deleted because they're not in the filter.
+            # We should confirm with the user that this is what they want to do.
+
+            dirs_deleted = [d for d in diff.dirs_deleted if not self.matcher.match(d, is_directory=True)]
+            files_deleted = [f for f in diff.files_deleted if not self.matcher.match(f, is_directory=False)]
+
+            diff = SnapshotDiff(
+                files_created=[],
+                files_modified=[],
+                dirs_created=[],
+                dirs_deleted=dirs_deleted,
+                files_deleted=files_deleted,
+            )
+
+            op_count = 0
+
+            # Dry run, so we don't need a session.
+            session = None
+
+            deleted_dirs = []
+
+            op_count += await self._apply_dirs_deleted(diff, session, deleted_dirs)
+            op_count += await self._apply_files_deleted(diff, session, deleted_dirs)
+
+            return op_count
+        finally:
+            self.dry_run = prev_dry_run
+
+    def _prepare_snapshot(self) -> DirectorySnapshot:
+        # When walking the directory tree, we use the ignore spec to do an initial first pass at excluding
+        # paths that should be definitely ignored.  Good examples of this are the .git folder, if it exists.
+        # This makes the directory walk more efficient.
+
+        def _filtered_listdir(root):
+            for entry in os.scandir(root):
+                entry_name = os.path.join(root, entry if isinstance(entry, str) else entry.name)
+                # Some paths are definitely ignored due to an ignore spec.  These should not be traversed.
+                if not self.matcher.should_ignore(entry_name, is_directory=os.path.isdir(entry_name)):
+                    yield entry
+
+        snapshot = DirectorySnapshot(self.source, listdir=_filtered_listdir)
+
+        # Now that we've walked the full tree, apply the path matcher to each path, which applies both
+        # the include and ignores rules.
+        matched_paths = {}
+        unmatched_paths = {}
+        for path, st in snapshot._stat_info.items():
+            if self.matcher.match(path, is_directory=snapshot.isdir(path)):
+                matched_paths[path] = st
+            else:
+                # Hold on to the unmatched paths, because we may need to include them due to them
+                # being ancestor directories of paths that are matched.
+                unmatched_paths[path] = st
+
+        # Make sure that all ancestor directories are included as well, even if not explicitly included
+        # via a rule.  This ensures that all ancestor directories will be created.
+        additional_matched_paths = {}
+        for path, st in unmatched_paths.items():
+            # We assume the target directory being synced to at this point already exists and doesn't need
+            # to be created.
+            if Path(path) == Path(self.source):
+                continue
+            for matched_path in matched_paths:
+                if matched_path.startswith(path) and os.path.commonpath([path, matched_path]) == path:
+                    additional_matched_paths[path] = st
+
+        # Replace the snapshot's path dictionary with the newly filtered set.
+        snapshot._stat_info = {**matched_paths, **additional_matched_paths}
+
+        return snapshot
+
+    async def _first_sync_sanity_checks(self, snapshot: DirectorySnapshot, diff: SnapshotDiff) -> SnapshotDiff:
+        """Performs sanity checks to help the user from making syncing mistakes.
+
+        One of the checks this performs is looking for unmatched deletes.  These are files/directories that will
+        be deleted that don't match the current set of filters.  The implication here is that the only reason they
+        are being deleted is because of a change in the filters.  For example, suppose a user syncs over the "foo"
+        directory with a "-i foo" option.  Then they change the filter to sync the "bar" directory with "-i bar".
+        This second sync would result in the "foo" directory being deleted in the remote.  This may or may not be
+        what the user wants, so we ask what they want to do.
+
+        The other check performed is to see whether there are any files matched by the current set of filters.
+        If there are no files matched then it might mean that the user made a mistake in the filters.  For example,
+        suppose they wanted all the Python files under "foo", but instead of `-ip "foo/*.py"` they wrote
+        `-ip "fo/*.py"`.
+
+        Args:
+            snapshot (DirectorySnapshot): the current snapshot of the files/directories in the source
+            diff (SnapshotDiff): diff comparing the current snapshot with the last snapshot from the previous run
+
+        Returns:
+            SnapshotDiff: the new diff to use, which has been updated based on the user's choice of how to handle
+                          unmatched deletes
+        """
+        dbx_echo("Checking if any unmatched files/directories would be deleted")
+        unmatched_delete_op_count = await self._dryrun_snapshot_diff_unmatched_deletes(diff)
+
+        if not snapshot.paths:
+            dbx_echo(
+                "WARNING: No files were found under the source directory with the current filters. "
+                "This means no files will be copied over."
+            )
+            dbx_echo(
+                "WARNING: Consider adjusting the patterns you are filtering on "
+                "(--include-pattern and --exclude-pattern)."
+            )
+
+        if unmatched_delete_op_count:
+            dbx_echo(
+                f"Detected {unmatched_delete_op_count} files and/or directories that will be deleted in the remote "
+                "location because they don't match the current include/exclude filters."
+            )
+
+            delete_unmatched_option = self.delete_unmatched_option
+
+            if delete_unmatched_option == DeleteUnmatchedOption.UNSPECIFIED_DELETE_UNMATCHED:
+                dbx_echo("You most likely have changed the include/exclude filters since the last run.")
+                dbx_echo("You can either:")
+                dbx_echo("1) proceed with deleting these files in the remote location, or")
+                dbx_echo("2) clear the paths from the local sync state so they won't be removed")
+                dbx_echo("Note: see options --allow-delete-unmatched and --disallow-delete-unmatched")
+
+                if click.confirm("Do you want to delete the files and directories above in the remote location?"):
+                    delete_unmatched_option = DeleteUnmatchedOption.ALLOW_DELETE_UNMATCHED
+                else:
+                    delete_unmatched_option = DeleteUnmatchedOption.DISALLOW_DELETE_UNMATCHED
+
+            if delete_unmatched_option == DeleteUnmatchedOption.ALLOW_DELETE_UNMATCHED:
+                dbx_echo("Unmatched files/directories will be removed in the remote location.")
+            else:
+                # Update the diff to remove the unmatched file/directory deletes so they aren't deleted.
+                dbx_echo("Unmatched files/directories will not be removed in the remote location.")
+                diff = self._remove_unmatched_deletes(diff)
+
+        return diff
+
+    async def incremental_copy(self) -> int:
+        """
+        Performs an incremental copy from source using the client.
+
+        Returns the number of operations performed or would have been performed (if dry run).
+        """
+
+        if self.is_first_sync:
+            if self.full_sync:
+                if not self.dry_run and os.path.exists(self.snapshot_path):
+                    os.remove(self.snapshot_path)
+                self.last_snapshot = EmptyDirectorySnapshot()
+            else:
+                if os.path.exists(self.snapshot_path):
+                    dbx_echo(f"Restoring sync snapshot from {self.snapshot_path}")
+                    with open(self.snapshot_path, "rb") as f:
+                        try:
+                            self.last_snapshot = pickle.load(f)
+                        except pickle.UnpicklingError:
+                            dbx_echo("Failed to restore sync state.  Starting from clean state.")
+                            self.last_snapshot = EmptyDirectorySnapshot()
+                else:
+                    self.last_snapshot = EmptyDirectorySnapshot()
+
+        snapshot = self._prepare_snapshot()
+
+        diff = compute_snapshot_diff(ref=self.last_snapshot, snapshot=snapshot)
+
+        if self.is_first_sync:
+            diff = await self._first_sync_sanity_checks(snapshot, diff)
+
+        connector = aiohttp.TCPConnector(limit=self.max_parallel)
+        async with aiohttp.ClientSession(connector=connector) as session:
+            op_count = await self._apply_snapshot_diff(diff, session)
+
+        self.last_snapshot = snapshot
+
+        # These aren't needed anymore because the directory walk has been completed, plus it prevents pickling.
+        self.last_snapshot.listdir = None
+        self.last_snapshot.stat = None
+
+        if not self.dry_run:
+            with open(self.snapshot_path, "wb") as f:
+                pickle.dump(self.last_snapshot, f)
+
+        self.is_first_sync = False
+
+        return op_count

--- a/dbx/sync/clients.py
+++ b/dbx/sync/clients.py
@@ -5,6 +5,7 @@ from abc import ABC, abstractmethod
 import aiohttp
 import requests
 from databricks_cli.configure.provider import DatabricksConfig
+from databricks_cli.version import version as databricks_cli_version
 
 from dbx.utils import dbx_echo
 
@@ -13,22 +14,16 @@ class ClientError(Exception):
     pass
 
 
-class BaseClient(ABC):
-    @abstractmethod
-    async def delete(self, sub_path: str, *, session: aiohttp.ClientSession, recursive: bool = False):
-        raise NotImplementedError
+def get_headers(api_token: str, sync_operation: str = "") -> dict:
 
-    @abstractmethod
-    async def mkdirs(self, sub_path: str, *, session: aiohttp.ClientSession):
-        raise NotImplementedError
+    # cicdtemplates is used elsewhere by dbx in the user agent string
+    command_name = f"cicdtemplates-sync-{sync_operation}"
 
-    @abstractmethod
-    async def put(self, sub_path: str, full_source_path: str, *, session: aiohttp.ClientSession):
-        raise NotImplementedError
-
-
-def get_auth_headers(api_token: str) -> dict:
-    headers = {"Authorization": f"Bearer {api_token}"}
+    headers = {
+        "Authorization": f"Bearer {api_token}",
+        # For consistency with dbx, this uses the same user agent format as Databricks CLI.
+        "user-agent": f"databricks-cli-{databricks_cli_version}-{command_name}",
+    }
     return headers
 
 
@@ -44,7 +39,7 @@ def get_user(config: DatabricksConfig) -> dict:
     """
     api_token = config.token
     host = config.host.rstrip("/")
-    headers = get_auth_headers(api_token)
+    headers = get_headers(api_token)
     url = f"{host}/api/2.0/preview/scim/v2/Me"
     resp = requests.get(url, headers=headers)
     if resp.status_code == 200:
@@ -64,52 +59,89 @@ async def _rate_limit_sleep(resp, *, default_sleep=0.5):
     await asyncio.sleep(retry_after)
 
 
-async def _api(
-    *, url: str, path: str, session: aiohttp.ClientSession, api_token: str, ok_status=None, ssl=None, **more_json_data
-):
-    if not ok_status:
-        ok_status = {200}
-    json_data = {"path": path, **more_json_data}
-    while True:
-        headers = get_auth_headers(api_token)
-        more_opts = {"ssl": ssl} if ssl is not None else {}
-        async with session.post(url=url, json=json_data, headers=headers, **more_opts) as resp:
-            if resp.status in ok_status:
-                break
-            if resp.status == 429:
-                dbx_echo("Rate limited")
-                await _rate_limit_sleep(resp)
-            else:
-                txt = await resp.text()
-                dbx_echo(f"HTTP {resp.status}: {txt}")
-                raise ClientError(resp.status)
+class BaseClient(ABC):
+    """
+    Base class for clients that support implementation of sync operations against locations in Databricks.
+    """
 
+    name = ""
 
-async def _api_delete(
-    *, api_base_path: str, path: str, session: aiohttp.ClientSession, recursive: bool = False, api_token: str, ssl=None
-):
-    dbx_echo(f"Deleting {path}")
-    more_opts = {"recursive": True} if recursive else {}
-    await _api(
-        url=f"{api_base_path}/delete",
-        path=path,
-        session=session,
-        api_token=api_token,
-        ok_status={200, 404},
-        ssl=ssl,
-        **more_opts,
-    )
+    @abstractmethod
+    async def delete(self, sub_path: str, *, session: aiohttp.ClientSession, recursive: bool = False):
+        raise NotImplementedError
 
+    @abstractmethod
+    async def mkdirs(self, sub_path: str, *, session: aiohttp.ClientSession):
+        raise NotImplementedError
 
-async def _api_mkdirs(*, api_base_path: str, path: str, session: aiohttp.ClientSession, api_token: str, ssl=None):
-    dbx_echo(f"Creating {path}")
-    await _api(url=f"{api_base_path}/mkdirs", path=path, session=session, ssl=ssl, api_token=api_token)
+    @abstractmethod
+    async def put(self, sub_path: str, full_source_path: str, *, session: aiohttp.ClientSession):
+        raise NotImplementedError
 
+    async def _api(
+        self,
+        *,
+        url: str,
+        path: str,
+        session: aiohttp.ClientSession,
+        api_token: str,
+        ok_status=None,
+        ssl=None,
+        **more_json_data,
+    ):
+        if not ok_status:
+            ok_status = {200}
+        json_data = {"path": path, **more_json_data}
+        while True:
+            headers = get_headers(api_token, self.name)
+            more_opts = {"ssl": ssl} if ssl is not None else {}
+            async with session.post(url=url, json=json_data, headers=headers, **more_opts) as resp:
+                if resp.status in ok_status:
+                    break
+                if resp.status == 429:
+                    dbx_echo("Rate limited")
+                    await _rate_limit_sleep(resp)
+                else:
+                    txt = await resp.text()
+                    dbx_echo(f"HTTP {resp.status}: {txt}")
+                    raise ClientError(resp.status)
 
-async def _api_put(*, api_base_path: str, path: str, session: aiohttp.ClientSession, api_token: str, ssl=None, **data):
-    dbx_echo(f"Putting {path}")
-    more_opts = {"overwrite": True, **data}
-    await _api(url=f"{api_base_path}/put", path=path, session=session, api_token=api_token, ssl=ssl, **more_opts)
+    async def _api_delete(
+        self,
+        *,
+        api_base_path: str,
+        path: str,
+        session: aiohttp.ClientSession,
+        recursive: bool = False,
+        api_token: str,
+        ssl=None,
+    ):
+        dbx_echo(f"Deleting {path}")
+        more_opts = {"recursive": True} if recursive else {}
+        await self._api(
+            url=f"{api_base_path}/delete",
+            path=path,
+            session=session,
+            api_token=api_token,
+            ok_status={200, 404},
+            ssl=ssl,
+            **more_opts,
+        )
+
+    async def _api_mkdirs(
+        self, *, api_base_path: str, path: str, session: aiohttp.ClientSession, api_token: str, ssl=None
+    ):
+        dbx_echo(f"Creating {path}")
+        await self._api(url=f"{api_base_path}/mkdirs", path=path, session=session, ssl=ssl, api_token=api_token)
+
+    async def _api_put(
+        self, *, api_base_path: str, path: str, session: aiohttp.ClientSession, api_token: str, ssl=None, **data
+    ):
+        dbx_echo(f"Putting {path}")
+        more_opts = {"overwrite": True, **data}
+        await self._api(
+            url=f"{api_base_path}/put", path=path, session=session, api_token=api_token, ssl=ssl, **more_opts
+        )
 
 
 def check_path(path: str) -> None:
@@ -137,7 +169,7 @@ class DBFSClient(BaseClient):
     async def delete(self, sub_path: str, *, session: aiohttp.ClientSession, recursive: bool = False):
         check_path(sub_path)
         path = f"{self.base_path}/{sub_path}"
-        await _api_delete(
+        await self._api_delete(
             api_base_path=self.api_base_path,
             path=path,
             session=session,
@@ -149,7 +181,7 @@ class DBFSClient(BaseClient):
     async def mkdirs(self, sub_path: str, *, session: aiohttp.ClientSession):
         check_path(sub_path)
         path = f"{self.base_path}/{sub_path}"
-        await _api_mkdirs(
+        await self._api_mkdirs(
             api_base_path=self.api_base_path, path=path, session=session, api_token=self.api_token, ssl=self.ssl
         )
 
@@ -164,7 +196,7 @@ class DBFSClient(BaseClient):
         path = f"{self.base_path}/{sub_path}"
         with open(full_source_path, "rb") as f:
             contents = base64.b64encode(f.read()).decode("ascii")
-        await _api_put(
+        await self._api_put(
             api_base_path=self.api_base_path,
             path=path,
             session=session,
@@ -196,7 +228,7 @@ class ReposClient(BaseClient):
     async def delete(self, sub_path: str, *, session: aiohttp.ClientSession, recursive: bool = False):
         check_path(sub_path)
         path = f"{self.base_path}/{sub_path}"
-        await _api_delete(
+        await self._api_delete(
             api_base_path=self.workspace_api_base_path,
             path=path,
             session=session,
@@ -208,7 +240,7 @@ class ReposClient(BaseClient):
     async def mkdirs(self, sub_path: str, *, session: aiohttp.ClientSession):
         check_path(sub_path)
         path = f"{self.base_path}/{sub_path}"
-        await _api_mkdirs(
+        await self._api_mkdirs(
             api_base_path=self.workspace_api_base_path,
             path=path,
             session=session,
@@ -226,7 +258,7 @@ class ReposClient(BaseClient):
             url = f"{self.workspace_files_api_base_path}/{path}"
             params = {"overwrite": "true"}
             while True:
-                headers = get_auth_headers(self.api_token)
+                headers = get_headers(self.api_token, self.name)
                 more_opts = {"ssl": self.ssl} if self.ssl is not None else {}
                 async with session.post(url=url, data=content, params=params, headers=headers, **more_opts) as resp:
                     if resp.status == 200:

--- a/dbx/sync/clients.py
+++ b/dbx/sync/clients.py
@@ -16,17 +16,17 @@ class ClientError(Exception):
 class BaseClient(ABC):
     @abstractmethod
     async def delete(self, sub_path: str, *, session: aiohttp.ClientSession, recursive: bool = False):
-        pass
+        raise NotImplementedError
 
     @abstractmethod
     async def mkdirs(self, sub_path: str, *, session: aiohttp.ClientSession):
-        pass
+        raise NotImplementedError
 
     @abstractmethod
     async def put(
         self, sub_path: str, full_source_path: str, *, session: aiohttp.ClientSession, overwrite: bool = True
     ):
-        pass
+        raise NotImplementedError
 
 
 def get_auth_headers(api_token: str) -> dict:

--- a/dbx/sync/clients.py
+++ b/dbx/sync/clients.py
@@ -1,0 +1,198 @@
+import asyncio
+import base64
+from abc import ABC, abstractmethod
+
+import aiohttp
+from databricks_cli.configure.provider import DatabricksConfig
+
+from dbx.utils import dbx_echo
+
+
+class ClientError(Exception):
+    pass
+
+
+class BaseClient(ABC):
+    @abstractmethod
+    async def delete(self, sub_path: str, *, session: aiohttp.ClientSession, recursive: bool = False):
+        pass
+
+    @abstractmethod
+    async def mkdirs(self, sub_path: str, *, session: aiohttp.ClientSession):
+        pass
+
+    @abstractmethod
+    async def put(
+        self, sub_path: str, full_source_path: str, *, session: aiohttp.ClientSession, overwrite: bool = True
+    ):
+        pass
+
+
+def get_auth_headers(api_token: str) -> dict:
+    headers = {"Authorization": f"Bearer {api_token}"}
+    return headers
+
+
+async def _rate_limit_sleep(resp, *, default_sleep=0.5):
+    """
+    Sleep in response to a rate limit (429) error.
+    """
+
+    retry_after = default_sleep
+    if resp.headers.get("Retry-After"):
+        retry_after = int(resp.headers["Retry-After"])
+    dbx_echo(f"Sleeping {retry_after:.1f} seconds")
+    await asyncio.sleep(retry_after)
+
+
+async def _api_delete(
+    *, api_base_path: str, path: str, session: aiohttp.ClientSession, recursive: bool = False, api_token: str
+):
+    dbx_echo(f"Deleting {path}")
+    json_data = dict(path=path)
+    if recursive:
+        json_data["recursive"] = recursive
+    while True:
+        headers = get_auth_headers(api_token)
+        async with session.post(url=f"{api_base_path}/delete", json=json_data, headers=headers) as resp:
+            if resp.status in {200, 404}:
+                break
+            if resp.status == 429:
+                dbx_echo("Rate limited")
+                await _rate_limit_sleep(resp)
+            else:
+                txt = await resp.text()
+                dbx_echo(f"HTTP {resp.status}: {txt}")
+                raise ClientError(resp.status)
+
+
+async def _api_mkdirs(*, api_base_path: str, path: str, session: aiohttp.ClientSession, api_token: str):
+    dbx_echo(f"Creating {path}")
+    json_data = dict(path=path)
+    while True:
+        headers = get_auth_headers(api_token)
+        async with session.post(url=f"{api_base_path}/mkdirs", json=json_data, headers=headers) as resp:
+            if resp.status == 200:
+                break
+            if resp.status == 429:
+                dbx_echo("Rate limited")
+                await _rate_limit_sleep(resp)
+            else:
+                txt = await resp.text()
+                dbx_echo(f"HTTP {resp.status}: {txt}")
+                raise ClientError(resp.status)
+
+
+def check_path(path: str) -> None:
+    if not path:
+        raise ValueError("Path is empty")
+    if "\\" in path:
+        raise ValueError("Paths should not contain backslashes")
+
+
+class DBFSClient(BaseClient):
+    name = "dbfs"
+
+    def __init__(self, *, base_path: str, config: DatabricksConfig):
+        check_path(base_path)
+        self.base_path = "dbfs:" + base_path.rstrip("/")
+        self.api_token = config.token
+        self.host = config.host.rstrip("/")
+        self.api_base_path = f"{self.host}/api/2.0/dbfs"
+
+        dbx_echo(f"Target base path: {self.base_path}")
+
+    async def delete(self, sub_path: str, *, session: aiohttp.ClientSession, recursive: bool = False):
+        check_path(sub_path)
+        path = f"{self.base_path}/{sub_path}"
+        await _api_delete(
+            api_base_path=self.api_base_path, path=path, session=session, recursive=recursive, api_token=self.api_token
+        )
+
+    async def mkdirs(self, sub_path: str, *, session: aiohttp.ClientSession):
+        check_path(sub_path)
+        path = f"{self.base_path}/{sub_path}"
+        await _api_mkdirs(api_base_path=self.api_base_path, path=path, session=session, api_token=self.api_token)
+
+    async def put(
+        self, sub_path: str, full_source_path: str, *, session: aiohttp.ClientSession, overwrite: bool = True
+    ):
+        check_path(sub_path)
+        path = f"{self.base_path}/{sub_path}"
+        dbx_echo(f"Putting {path}")
+        with open(full_source_path, "rb") as f:
+            contents = base64.b64encode(f.read()).decode("ascii")
+            json_data = dict(path=path, contents=contents, overwrite=overwrite)
+            while True:
+                headers = get_auth_headers(self.api_token)
+                async with session.post(url=f"{self.host}/api/2.0/dbfs/put", json=json_data, headers=headers) as resp:
+                    if resp.status == 200:
+                        break
+                    if resp.status == 429:
+                        dbx_echo("Rate limited")
+                        await _rate_limit_sleep(resp)
+                    else:
+                        txt = await resp.text()
+                        dbx_echo(f"HTTP {resp.status}: {txt}")
+                        raise ClientError(resp.status)
+
+
+class ReposClient(BaseClient):
+    name = "repos"
+
+    def __init__(self, *, user: str, repo_name: str, config: DatabricksConfig):
+        if not user:
+            raise ValueError("Expected a user")
+        if not repo_name:
+            raise ValueError("repo_name is required")
+        self.base_path = f"/Repos/{user}/{repo_name}"
+        self.api_token = config.token
+        self.host = config.host.rstrip("/")
+        self.workspace_api_base_path = f"{self.host}/api/2.0/workspace"
+        self.workspace_files_api_base_path = f"{self.host}/api/2.0/workspace-files/import-file"
+
+        dbx_echo(f"Target base path: {self.base_path}")
+
+    async def delete(self, sub_path: str, *, session: aiohttp.ClientSession, recursive: bool = False):
+        check_path(sub_path)
+        path = f"{self.base_path}/{sub_path}"
+        await _api_delete(
+            api_base_path=self.workspace_api_base_path,
+            path=path,
+            session=session,
+            recursive=recursive,
+            api_token=self.api_token,
+        )
+
+    async def mkdirs(self, sub_path: str, *, session: aiohttp.ClientSession):
+        check_path(sub_path)
+        path = f"{self.base_path}/{sub_path}"
+        await _api_mkdirs(
+            api_base_path=self.workspace_api_base_path, path=path, session=session, api_token=self.api_token
+        )
+
+    async def put(
+        self, sub_path: str, full_source_path: str, *, session: aiohttp.ClientSession, overwrite: bool = True
+    ):
+        check_path(sub_path)
+        path = f"{self.base_path}/{sub_path}"
+        dbx_echo(f"Putting {path}")
+        with open(full_source_path, "rb") as f:
+            content = f.read()
+            path = path.lstrip("/")
+            url = f"{self.workspace_files_api_base_path}/{path}"
+            params = {}
+            if overwrite:
+                params["overwrite"] = "true"
+            while True:
+                headers = get_auth_headers(self.api_token)
+                async with session.post(url=url, data=content, params=params, headers=headers) as resp:
+                    if resp.status == 200:
+                        break
+                    if resp.status == 429:
+                        dbx_echo("Rate limited")
+                        await _rate_limit_sleep(resp)
+                    else:
+                        txt = await resp.text()
+                        dbx_echo(f"HTTP {resp.status}: {txt}")
+                        raise ClientError(resp.status)

--- a/dbx/sync/config.py
+++ b/dbx/sync/config.py
@@ -1,0 +1,61 @@
+import sys
+
+import click
+import databricks_cli
+import requests
+from databricks_cli.configure.provider import DatabricksConfig, ProfileConfigProvider, get_config
+
+from .clients import get_auth_headers
+
+
+def has_valid_token(config: DatabricksConfig) -> bool:
+    """Check that the Databricks config has a valid token that works with the host.
+
+    Args:
+        config (DatabricksConfig): config with token and host
+
+    Returns:
+        bool: True if token can be used to call API, and False otherwise
+    """
+    token = config.token
+    host = config.host.rstrip("/")
+    headers = get_auth_headers(token)
+    resp = requests.get(f"{host}/api/2.0/dbfs/list", json={"path": "/"}, headers=headers)
+    return resp.status_code == 200
+
+
+def get_databricks_config(profile: str = None) -> DatabricksConfig:
+    """
+    Returns the Databricks config with the token and host for accessing Databricks while also validating that
+    the token works with that host.
+
+    The config is provided by classes in the Databricks CLI.
+    """
+
+    try:
+        if profile:
+            config = ProfileConfigProvider(profile).get_config()
+        else:
+            config = get_config()
+    except databricks_cli.utils.InvalidConfigurationError as e:
+
+        # If the Databricks CLI hasn't been configured yet, it will produce an error message.  But the error
+        # message is confusing because it says we need to run `dbx configure`, rather than
+        # `databricks configure`.  Databricks CLI code makes the reasonable assumption that sys.argv[0] is the
+        # program to run, as it's usually called within its own CLI.
+        # We correct this be replacing it with "databricks".
+        msg = str(e)
+        msg = msg.replace(sys.argv[0], "databricks")
+        msg = msg.replace("the CLI yet", "the Databricks CLI yet")
+
+        raise click.UsageError(msg)
+
+    profile_str = f" for profile {profile}" if profile else ""
+
+    if not config:
+        raise click.UsageError(f"Could not find a databricks-cli config{profile_str}")
+
+    if not has_valid_token(config):
+        raise click.UsageError(f"Invalid token found for databricks-cli config{profile_str}")
+
+    return config

--- a/dbx/sync/config.py
+++ b/dbx/sync/config.py
@@ -5,7 +5,7 @@ import databricks_cli
 import requests
 from databricks_cli.configure.provider import DatabricksConfig, ProfileConfigProvider, get_config
 
-from .clients import get_auth_headers
+from .clients import get_headers
 
 
 def has_valid_token(config: DatabricksConfig) -> bool:
@@ -19,7 +19,7 @@ def has_valid_token(config: DatabricksConfig) -> bool:
     """
     token = config.token
     host = config.host.rstrip("/")
-    headers = get_auth_headers(token)
+    headers = get_headers(token)
     resp = requests.get(f"{host}/api/2.0/dbfs/list", json={"path": "/"}, headers=headers)
     return resp.status_code == 200
 

--- a/dbx/sync/constants.py
+++ b/dbx/sync/constants.py
@@ -1,0 +1,3 @@
+from dbx.constants import DBX_PATH
+
+DBX_SYNC_DIR = DBX_PATH / "sync"

--- a/dbx/sync/event_handler.py
+++ b/dbx/sync/event_handler.py
@@ -1,0 +1,90 @@
+import threading
+from contextlib import contextmanager
+from typing import List
+
+from watchdog.events import FileSystemEvent, FileSystemEventHandler
+from watchdog.observers import Observer
+
+from .path_matcher import PathMatcher
+
+
+class CollectingEventHandler(FileSystemEventHandler):
+    """A watchdog event handler that collects all the events captured so they can be retrieved in batches."""
+
+    def __init__(self, *, matcher: PathMatcher = None):
+        super().__init__()
+
+        self.lock = threading.RLock()
+        self.events = []
+        self.matcher = matcher
+
+    def _should_ignore(self, event: FileSystemEvent) -> bool:
+        return not self.matcher.match(event.src_path, is_directory=event.is_directory) if self.matcher else False
+
+    def get_events(self) -> List[FileSystemEvent]:
+        """Gets the events collected since the last time this method was called.
+
+        Returns:
+            List[FileSystemEvent]: events collected since the last call
+        """
+        with self.lock:
+            result = self.events
+            self.events = []
+            return result
+
+    def on_moved(self, event: FileSystemEvent) -> None:
+        with self.lock:
+            super().on_moved(event)
+            if not self._should_ignore(event):
+                self.events.append(event)
+
+    def on_created(self, event: FileSystemEvent) -> None:
+        with self.lock:
+            super().on_created(event)
+            if not self._should_ignore(event):
+                self.events.append(event)
+
+    def on_deleted(self, event: FileSystemEvent) -> None:
+        with self.lock:
+            super().on_deleted(event)
+            if not self._should_ignore(event):
+                self.events.append(event)
+
+    def on_modified(self, event: FileSystemEvent) -> None:
+        with self.lock:
+            super().on_modified(event)
+            if not self._should_ignore(event):
+                self.events.append(event)
+
+
+@contextmanager
+def file_watcher(*, source: str, matcher: PathMatcher):
+    """Watches a source directory for changes to files, filtered by the given path matcher.
+
+    This yields an event handler that can be used to retrieve file events within the context of this
+    context manager.
+
+    For example,
+
+        event_handler.get_events()
+
+    will return all the file events that occurred since the last time it was called.
+
+    Args:
+        source (str): source directory to watch for changes
+        matcher (PathMatcher): used to identify which files to pay attention to and which to ignore
+
+    Yields:
+        CollectingEventHandler: the event handler which collects together all the file events
+    """
+    event_handler = CollectingEventHandler(matcher=matcher)
+    observer = Observer()
+    observer.schedule(event_handler, source, recursive=True)
+    observer.start()
+
+    try:
+        yield event_handler
+    except KeyboardInterrupt:
+        pass
+    observer.stop()
+    observer.join()

--- a/dbx/sync/path_matcher.py
+++ b/dbx/sync/path_matcher.py
@@ -1,0 +1,128 @@
+import os
+from pathlib import Path
+from typing import List, Union
+
+import pathspec
+
+
+def path_as_posix(path: Union[str, Path]) -> str:
+    if isinstance(path, str):
+        ends_with_sep = path.endswith("/") or path.endswith("\\")
+        path = Path(path).as_posix()
+        if ends_with_sep:
+            path = path + "/"
+    else:
+        path = path.as_posix()
+    return path
+
+
+class PathMatcher:
+    """
+    Applies gitignore-style ignore and include patterns to match file paths.
+
+    Initialized with defaults for ignores and includes, this will match every path that is passed in, as long
+    as it is under the root directory (otherwise it would be an error).
+
+    Initialized with only ignores, this will match any path that does not match one of the ignore patterns.
+
+    Initialized with only includes, this will only match paths that match one of the include patterns.
+
+    Both ignores and includes can be specified together, where ignores take precedence.
+    """
+
+    def __init__(self, root_dir: Union[str, Path], *, ignores: List[str] = None, includes: List[str] = None):
+        """Initialize
+
+        Args:
+            root_dir (str): the root directory that the ignore and include patterns are relative to
+            ignores (List[str], optional): patterns to ignore. Defaults to None, which means nothing will be
+                                           ignored by default.
+            includes (List[str], optional): patterns to include. Defaults to None, which means everything will be
+                                            included, unless otherwise ignored.
+        """
+
+        self.root_dir = path_as_posix(root_dir)
+        self.include_spec = pathspec.PathSpec.from_lines("gitwildmatch", includes) if includes else None
+        self.ignore_spec = pathspec.PathSpec.from_lines("gitwildmatch", ignores) if ignores else None
+
+    def _clean_relative_path(self, path: str, *, is_directory: bool) -> str:
+        # pathspec does not check if a path is a directory, so we need to tell it by adding a trailing slash.
+        if not path.endswith("/"):
+            # Note: it's possible that the path may no longer exist.  therefore the is_directory flag is useful in
+            # this case.
+            if is_directory or os.path.isdir(path):
+                path = path + "/"
+        elif is_directory is False:
+            raise ValueError("Path should not end in '/' and also not be a directory")
+
+        path = path[len(self.root_dir) + 1 :]
+
+        return path
+
+    def should_ignore(self, path: Union[str, Path], *, is_directory: bool = None) -> bool:
+        """Check if the path should be ignored due to an ignore spec.
+
+        Args:
+            path (Union[str, Path]): path to check
+            is_directory (bool, optional): True if this is a directory, False otherwise.  By default this is None,
+                                           meaning it is unspecified.
+
+        Returns:
+            bool: True if it should be ignored due to the ignore spec
+        """
+        path = path_as_posix(path)
+
+        path = self._clean_relative_path(path, is_directory=is_directory)
+
+        # If there is an ignore spec, then we'll ignore any paths that match.
+        if self.ignore_spec is not None:
+            return self.ignore_spec.match_file(path)
+
+        return False
+
+    def match(self, path: Union[str, Path], *, is_directory: bool = None) -> bool:
+        """Check if the path should be matched.  This happens when either:
+
+        1) A list of ignore patterns have been provided and the path matches one of those patterns.
+        2) A list of include patterns has been provided and the path does not match one of those patterns.
+
+        gitignore patterns distinguish between files and directories using a trailing slash.  For the path passed
+        into this function, a directory can be indicated either by appending a slash or by setting is_directory
+        to True.  If neither of these are used, then a slash is automatically appended if the path exists and
+        is a directory.
+
+        Args:
+            path (str): the path to check
+            is_directory (bool, optional): True if this is a directory, False otherwise.  By default this is None,
+                                           meaning it is unspecified.
+
+        Returns:
+            bool: True if the path should be ignored, and False otherwise
+        """
+
+        path = path_as_posix(path)
+
+        # Sometimes we get events that are outside of the root directory.  For example we may get a directory
+        # creation event about the source directory, which also results in a modification event for the parent
+        # of the source directory.
+        if not path.startswith(self.root_dir + "/"):
+            return False
+
+        # This class only matches files within a source directory, but not that source directory itself.
+        if path.rstrip("/") == self.root_dir:
+            return False
+
+        path = self._clean_relative_path(path, is_directory=is_directory)
+
+        # If there is an ignore spec, then we'll ignore any paths that match, regardless of the include spec.
+        if self.ignore_spec is not None:
+            should_ignore = self.ignore_spec.match_file(path)
+            if should_ignore:
+                return False
+
+        # If there is an include spec, then we'll ignore any paths that don't match.  If there isn't an include
+        # spec then we'll include everything by default.
+        if self.include_spec is not None:
+            return self.include_spec.match_file(path)
+
+        return True

--- a/dbx/sync/snapshot.py
+++ b/dbx/sync/snapshot.py
@@ -1,0 +1,64 @@
+from collections import namedtuple
+
+from watchdog.utils.dirsnapshot import DirectorySnapshot
+
+SnapshotDiff = namedtuple(
+    "SnapshotDiff", ["files_created", "files_deleted", "files_modified", "dirs_created", "dirs_deleted"]
+)
+
+
+def compute_snapshot_diff(ref: DirectorySnapshot, snapshot: DirectorySnapshot) -> SnapshotDiff:
+    """Computes a diff between two directory snapshots at different points in time.
+
+    See SnapshotDiff for what changes this detects.  This ignores changes to attributes of directories,
+    such as the modification time.  It also does not attempt to detect moves.  A move is represented
+    as a delete and create.
+
+    This diff is useful for applying changes to a remote blob storage system that supports CRUD operations.
+    Typically these systems don't support move operations, which is why detecting moves is not a priority.
+
+    Args:
+        ref (DirectorySnapshot): what we're comparing against (the old snapshot)
+        snapshot (DirectorySnapshot): the new snapshot
+
+    Returns:
+        SnapshotDiff: record of what has changed between the snapshots
+    """
+    created = snapshot.paths - ref.paths
+    deleted = ref.paths - snapshot.paths
+
+    # any paths that exist in both ref and snapshot may have been modified, so we'll need to do some checks.
+    modified_candidates = ref.paths & snapshot.paths
+
+    # check if file was replaced with a dir, or dir was replaced with a file
+    for path in modified_candidates:
+        snapshot_is_dir = snapshot.isdir(path)
+        ref_is_dir = ref.isdir(path)
+        if (snapshot_is_dir and not ref_is_dir) or (not snapshot_is_dir and ref_is_dir):
+            created.add(path)
+            deleted.add(path)
+
+    # anything created or deleted is by definition not modified
+    modified_candidates = modified_candidates - created - deleted
+
+    # check if any of remaining candidates were modified based on size or mtime changes
+    modified = set()
+    for path in modified_candidates:
+        if ref.mtime(path) != snapshot.mtime(path) or ref.size(path) != snapshot.size(path):
+            modified.add(path)
+
+    dirs_created = sorted([path for path in created if snapshot.isdir(path)])
+    dirs_deleted = sorted([path for path in deleted if ref.isdir(path)])
+    dirs_modified = sorted([path for path in modified if ref.isdir(path)])
+
+    files_created = sorted(list(created - set(dirs_created)))
+    files_deleted = sorted(list(deleted - set(dirs_deleted)))
+    files_modified = sorted(list(modified - set(dirs_modified)))
+
+    return SnapshotDiff(
+        files_created=files_created,
+        files_deleted=files_deleted,
+        files_modified=files_modified,
+        dirs_created=dirs_created,
+        dirs_deleted=dirs_deleted,
+    )

--- a/dbx/sync/snapshot.py
+++ b/dbx/sync/snapshot.py
@@ -1,10 +1,16 @@
-from collections import namedtuple
+from dataclasses import dataclass
+from typing import List
 
 from watchdog.utils.dirsnapshot import DirectorySnapshot
 
-SnapshotDiff = namedtuple(
-    "SnapshotDiff", ["files_created", "files_deleted", "files_modified", "dirs_created", "dirs_deleted"]
-)
+
+@dataclass
+class SnapshotDiff:
+    files_created: List[str]
+    files_deleted: List[str]
+    files_modified: List[str]
+    dirs_created: List[str]
+    dirs_deleted: List[str]
 
 
 def compute_snapshot_diff(ref: DirectorySnapshot, snapshot: DirectorySnapshot) -> SnapshotDiff:

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -9,6 +9,7 @@ rst2pdf==0.99
 wheel
 path
 pytest
+pytest-asyncio
 pytest-cov
 pytest-timeout
 pytest-clarity

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,3 +17,6 @@ log_cli_level = "INFO"
 log_cli_format = "[pytest][%(asctime)s][%(levelname)s][%(module)s][%(funcName)s] %(message)s"
 log_cli_date_format = "%Y-%m-%d %H:%M:%S"
 log_level = "INFO"
+pythonpath = [
+  "."
+]

--- a/setup.py
+++ b/setup.py
@@ -22,6 +22,9 @@ INSTALL_REQUIRES = [
     "emoji>=1.6.1",
     "cookiecutter>=1.7.2",
     "Jinja2>=2.11.2",
+    "aiohttp>=3.8.1",
+    "pathspec>=0.9.0",
+    "watchdog>=2.1.0",
 ]
 
 if sys.platform.startswith("win32"):
@@ -29,7 +32,7 @@ if sys.platform.startswith("win32"):
 
 setup(
     name="dbx",
-    python_requires=">=3.7",
+    python_requires=">=3.8",
     packages=find_packages(exclude=["tests", "tests.*"]),
     setup_requires=["wheel"],
     install_requires=INSTALL_REQUIRES,

--- a/tests/unit/sync/clients/conftest.py
+++ b/tests/unit/sync/clients/conftest.py
@@ -1,0 +1,21 @@
+import os
+import tempfile
+from tests.unit.sync.utils import mocked_props
+
+import pytest
+
+from tests.unit.sync.utils import temporary_directory
+
+
+@pytest.fixture
+def mock_config():
+    return mocked_props(token="fake-token", host="http://fakehost.asdf/base/")
+
+
+@pytest.fixture
+def dummy_file_path() -> str:
+    with temporary_directory() as tempdir:
+        file_path = os.path.join(tempdir, "file")
+        with open(file_path, "w") as f:
+            f.write("yo")
+        yield file_path

--- a/tests/unit/sync/clients/conftest.py
+++ b/tests/unit/sync/clients/conftest.py
@@ -9,7 +9,7 @@ from tests.unit.sync.utils import temporary_directory
 
 @pytest.fixture
 def mock_config():
-    return mocked_props(token="fake-token", host="http://fakehost.asdf/base/")
+    return mocked_props(token="fake-token", host="http://fakehost.asdf/base/", insecure=None)
 
 
 @pytest.fixture

--- a/tests/unit/sync/clients/test_dbfs_client.py
+++ b/tests/unit/sync/clients/test_dbfs_client.py
@@ -6,6 +6,7 @@ from unittest.mock import AsyncMock, MagicMock, PropertyMock
 import pytest
 
 from dbx.sync.clients import ClientError, DBFSClient
+from tests.unit.sync.utils import mocked_props
 
 
 @pytest.fixture
@@ -28,6 +29,37 @@ def test_delete(client: DBFSClient):
     assert session.post.call_count == 1
     assert session.post.call_args[1]["url"] == "http://fakehost.asdf/base/api/2.0/dbfs/delete"
     assert session.post.call_args[1]["json"] == {"path": "dbfs:/tmp/foo/foo/bar"}
+    assert "ssl" not in session.post.call_args[1]
+
+
+def test_delete_secure(client: DBFSClient):
+    mock_config = mocked_props(token="fake-token", host="http://fakehost.asdf/base/", insecure=False)
+    client = DBFSClient(base_path="/tmp/foo", config=mock_config)
+    session = MagicMock()
+    resp = MagicMock()
+    setattr(type(resp), "status", PropertyMock(return_value=200))
+    session.post.return_value = create_async_with_result(resp)
+    asyncio.run(client.delete(sub_path="foo/bar", session=session))
+
+    assert session.post.call_count == 1
+    assert session.post.call_args[1]["url"] == "http://fakehost.asdf/base/api/2.0/dbfs/delete"
+    assert session.post.call_args[1]["json"] == {"path": "dbfs:/tmp/foo/foo/bar"}
+    assert session.post.call_args[1]["ssl"] is True
+
+
+def test_delete_secure(client: DBFSClient):
+    mock_config = mocked_props(token="fake-token", host="http://fakehost.asdf/base/", insecure=True)
+    client = DBFSClient(base_path="/tmp/foo", config=mock_config)
+    session = MagicMock()
+    resp = MagicMock()
+    setattr(type(resp), "status", PropertyMock(return_value=200))
+    session.post.return_value = create_async_with_result(resp)
+    asyncio.run(client.delete(sub_path="foo/bar", session=session))
+
+    assert session.post.call_count == 1
+    assert session.post.call_args[1]["url"] == "http://fakehost.asdf/base/api/2.0/dbfs/delete"
+    assert session.post.call_args[1]["json"] == {"path": "dbfs:/tmp/foo/foo/bar"}
+    assert session.post.call_args[1]["ssl"] is False
 
 
 def test_delete_backslash(client: DBFSClient):

--- a/tests/unit/sync/clients/test_dbfs_client.py
+++ b/tests/unit/sync/clients/test_dbfs_client.py
@@ -6,7 +6,7 @@ from unittest.mock import AsyncMock, MagicMock, PropertyMock
 import pytest
 
 from dbx.sync.clients import ClientError, DBFSClient
-from tests.unit.sync.utils import mocked_props
+from tests.unit.sync.utils import mocked_props, is_dbfs_user_agent
 
 
 @pytest.fixture
@@ -30,6 +30,8 @@ def test_delete(client: DBFSClient):
     assert session.post.call_args[1]["url"] == "http://fakehost.asdf/base/api/2.0/dbfs/delete"
     assert session.post.call_args[1]["json"] == {"path": "dbfs:/tmp/foo/foo/bar"}
     assert "ssl" not in session.post.call_args[1]
+    assert session.post.call_args[1]["headers"]["Authorization"] == "Bearer fake-token"
+    assert is_dbfs_user_agent(session.post.call_args[1]["headers"]["user-agent"])
 
 
 def test_delete_secure(client: DBFSClient):
@@ -151,6 +153,8 @@ def test_mkdirs(client: DBFSClient):
     assert session.post.call_count == 1
     assert session.post.call_args[1]["url"] == "http://fakehost.asdf/base/api/2.0/dbfs/mkdirs"
     assert session.post.call_args[1]["json"] == {"path": "dbfs:/tmp/foo/foo/bar"}
+    assert session.post.call_args[1]["headers"]["Authorization"] == "Bearer fake-token"
+    assert is_dbfs_user_agent(session.post.call_args[1]["headers"]["user-agent"])
 
 
 def test_mkdirs_backslash(client: DBFSClient):
@@ -235,6 +239,8 @@ def test_put(client: DBFSClient, dummy_file_path: str):
         "contents": base64.b64encode(b"yo").decode("ascii"),
         "overwrite": True,
     }
+    assert session.post.call_args[1]["headers"]["Authorization"] == "Bearer fake-token"
+    assert is_dbfs_user_agent(session.post.call_args[1]["headers"]["user-agent"])
 
 
 def test_put_backslash(client: DBFSClient, dummy_file_path: str):

--- a/tests/unit/sync/clients/test_dbfs_client.py
+++ b/tests/unit/sync/clients/test_dbfs_client.py
@@ -1,0 +1,254 @@
+import asyncio
+import base64
+from tests.unit.sync.utils import create_async_with_result
+from unittest.mock import AsyncMock, MagicMock, PropertyMock
+
+import pytest
+
+from dbx.sync.clients import ClientError, DBFSClient
+
+
+@pytest.fixture
+def client(mock_config) -> DBFSClient:
+    return DBFSClient(base_path="/tmp/foo", config=mock_config)
+
+
+def test_init(client):
+    assert client.api_token == "fake-token"
+    assert client.host == "http://fakehost.asdf/base"
+
+
+def test_delete(client: DBFSClient):
+    session = MagicMock()
+    resp = MagicMock()
+    setattr(type(resp), "status", PropertyMock(return_value=200))
+    session.post.return_value = create_async_with_result(resp)
+    asyncio.run(client.delete(sub_path="foo/bar", session=session))
+
+    assert session.post.call_count == 1
+    assert session.post.call_args[1]["url"] == "http://fakehost.asdf/base/api/2.0/dbfs/delete"
+    assert session.post.call_args[1]["json"] == {"path": "dbfs:/tmp/foo/foo/bar"}
+
+
+def test_delete_no_path(client: DBFSClient):
+    session = MagicMock()
+    with pytest.raises(ValueError):
+        asyncio.run(client.delete(sub_path=None, session=session))
+
+
+def test_delete_recursive(client: DBFSClient):
+    session = MagicMock()
+    resp = MagicMock()
+    setattr(type(resp), "status", PropertyMock(return_value=200))
+    session.post.return_value = create_async_with_result(resp)
+    asyncio.run(client.delete(sub_path="foo/bar", session=session, recursive=True))
+
+    assert session.post.call_count == 1
+    assert session.post.call_args[1]["url"] == "http://fakehost.asdf/base/api/2.0/dbfs/delete"
+    assert session.post.call_args[1]["json"] == {"path": "dbfs:/tmp/foo/foo/bar", "recursive": True}
+
+
+def test_delete_rate_limited(client: DBFSClient):
+    session = MagicMock()
+
+    rate_limit_resp = MagicMock()
+    setattr(type(rate_limit_resp), "status", PropertyMock(return_value=429))
+
+    success_resp = MagicMock()
+    setattr(type(success_resp), "status", PropertyMock(return_value=200))
+    setattr(type(rate_limit_resp), "headers", PropertyMock(return_value={"Retry-After": None}))
+
+    session.post.side_effect = [create_async_with_result(rate_limit_resp), create_async_with_result(success_resp)]
+
+    asyncio.run(client.delete(sub_path="foo/bar", session=session))
+
+    assert session.post.call_count == 2
+    assert session.post.call_args[1]["url"] == "http://fakehost.asdf/base/api/2.0/dbfs/delete"
+    assert session.post.call_args[1]["json"] == {"path": "dbfs:/tmp/foo/foo/bar"}
+
+
+def test_delete_rate_limited_retry_after(client: DBFSClient):
+    session = MagicMock()
+
+    rate_limit_resp = MagicMock()
+    setattr(type(rate_limit_resp), "status", PropertyMock(return_value=429))
+    setattr(type(rate_limit_resp), "headers", PropertyMock(return_value={"Retry-After": 1}))
+
+    success_resp = MagicMock()
+    setattr(type(success_resp), "status", PropertyMock(return_value=200))
+
+    session.post.side_effect = [create_async_with_result(rate_limit_resp), create_async_with_result(success_resp)]
+
+    asyncio.run(client.delete(sub_path="foo/bar", session=session))
+
+    assert session.post.call_count == 2
+    assert session.post.call_args[1]["url"] == "http://fakehost.asdf/base/api/2.0/dbfs/delete"
+    assert session.post.call_args[1]["json"] == {"path": "dbfs:/tmp/foo/foo/bar"}
+
+
+def test_delete_unauthorized(client: DBFSClient):
+    session = MagicMock()
+
+    unauth_resp = AsyncMock()
+    setattr(type(unauth_resp), "status", PropertyMock(return_value=401))
+
+    session.post.return_value = unauth_resp
+
+    unauth_resp.text.return_value = "bad auth"
+
+    with pytest.raises(ClientError):
+        asyncio.run(client.delete(sub_path="foo/bar", session=session))
+
+
+def test_mkdirs(client: DBFSClient):
+    session = MagicMock()
+    resp = MagicMock()
+    setattr(type(resp), "status", PropertyMock(return_value=200))
+    session.post.return_value = create_async_with_result(resp)
+    asyncio.run(client.mkdirs(sub_path="foo/bar", session=session))
+
+    assert session.post.call_count == 1
+    assert session.post.call_args[1]["url"] == "http://fakehost.asdf/base/api/2.0/dbfs/mkdirs"
+    assert session.post.call_args[1]["json"] == {"path": "dbfs:/tmp/foo/foo/bar"}
+
+
+def test_mkdirs_no_path(client: DBFSClient):
+    session = MagicMock()
+    with pytest.raises(ValueError):
+        asyncio.run(client.mkdirs(sub_path=None, session=session))
+
+
+def test_mkdirs_rate_limited(client: DBFSClient):
+    session = MagicMock()
+
+    rate_limit_resp = MagicMock()
+    setattr(type(rate_limit_resp), "status", PropertyMock(return_value=429))
+
+    success_resp = MagicMock()
+    setattr(type(success_resp), "status", PropertyMock(return_value=200))
+    setattr(type(rate_limit_resp), "headers", PropertyMock(return_value={"Retry-After": None}))
+
+    session.post.side_effect = [create_async_with_result(rate_limit_resp), create_async_with_result(success_resp)]
+
+    asyncio.run(client.mkdirs(sub_path="foo/bar", session=session))
+
+    assert session.post.call_count == 2
+    assert session.post.call_args[1]["url"] == "http://fakehost.asdf/base/api/2.0/dbfs/mkdirs"
+    assert session.post.call_args[1]["json"] == {"path": "dbfs:/tmp/foo/foo/bar"}
+
+
+def test_mkdirs_rate_limited_retry_after(client: DBFSClient):
+    session = MagicMock()
+
+    rate_limit_resp = MagicMock()
+    setattr(type(rate_limit_resp), "status", PropertyMock(return_value=429))
+    setattr(type(rate_limit_resp), "headers", PropertyMock(return_value={"Retry-After": 1}))
+
+    success_resp = MagicMock()
+    setattr(type(success_resp), "status", PropertyMock(return_value=200))
+
+    session.post.side_effect = [create_async_with_result(rate_limit_resp), create_async_with_result(success_resp)]
+
+    asyncio.run(client.mkdirs(sub_path="foo/bar", session=session))
+
+    assert session.post.call_count == 2
+    assert session.post.call_args[1]["url"] == "http://fakehost.asdf/base/api/2.0/dbfs/mkdirs"
+    assert session.post.call_args[1]["json"] == {"path": "dbfs:/tmp/foo/foo/bar"}
+
+
+def test_mkdirs_unauthorized(client: DBFSClient):
+    session = MagicMock()
+
+    unauth_resp = AsyncMock()
+    setattr(type(unauth_resp), "status", PropertyMock(return_value=401))
+
+    session.post.return_value = unauth_resp
+
+    unauth_resp.text.return_value = "bad auth"
+
+    with pytest.raises(ClientError):
+        asyncio.run(client.mkdirs(sub_path="foo/bar", session=session))
+
+
+def test_put(client: DBFSClient, dummy_file_path: str):
+    session = MagicMock()
+    resp = MagicMock()
+    setattr(type(resp), "status", PropertyMock(return_value=200))
+    session.post.return_value = create_async_with_result(resp)
+
+    asyncio.run(client.put(sub_path="foo/bar", full_source_path=dummy_file_path, session=session))
+
+    assert session.post.call_count == 1
+    assert session.post.call_args[1]["url"] == "http://fakehost.asdf/base/api/2.0/dbfs/put"
+    assert session.post.call_args[1]["json"] == {
+        "path": "dbfs:/tmp/foo/foo/bar",
+        "contents": base64.b64encode(b"yo").decode("ascii"),
+        "overwrite": True,
+    }
+
+
+def test_put_no_path(client: DBFSClient, dummy_file_path: str):
+    session = MagicMock()
+
+    with pytest.raises(ValueError):
+        asyncio.run(client.put(sub_path=None, full_source_path=dummy_file_path, session=session))
+
+
+def test_put_rate_limited(client: DBFSClient, dummy_file_path: str):
+    session = MagicMock()
+
+    rate_limit_resp = MagicMock()
+    setattr(type(rate_limit_resp), "status", PropertyMock(return_value=429))
+
+    success_resp = MagicMock()
+    setattr(type(success_resp), "status", PropertyMock(return_value=200))
+    setattr(type(rate_limit_resp), "headers", PropertyMock(return_value={"Retry-After": None}))
+
+    session.post.side_effect = [create_async_with_result(rate_limit_resp), create_async_with_result(success_resp)]
+
+    asyncio.run(client.put(sub_path="foo/bar", full_source_path=dummy_file_path, session=session))
+
+    assert session.post.call_count == 2
+    assert session.post.call_args[1]["url"] == "http://fakehost.asdf/base/api/2.0/dbfs/put"
+    assert session.post.call_args[1]["json"] == {
+        "path": "dbfs:/tmp/foo/foo/bar",
+        "contents": base64.b64encode(b"yo").decode("ascii"),
+        "overwrite": True,
+    }
+
+
+def test_put_rate_limited_retry_after(client: DBFSClient, dummy_file_path: str):
+    session = MagicMock()
+
+    rate_limit_resp = MagicMock()
+    setattr(type(rate_limit_resp), "status", PropertyMock(return_value=429))
+    setattr(type(rate_limit_resp), "headers", PropertyMock(return_value={"Retry-After": 1}))
+
+    success_resp = MagicMock()
+    setattr(type(success_resp), "status", PropertyMock(return_value=200))
+
+    session.post.side_effect = [create_async_with_result(rate_limit_resp), create_async_with_result(success_resp)]
+
+    asyncio.run(client.put(sub_path="foo/bar", full_source_path=dummy_file_path, session=session))
+
+    assert session.post.call_count == 2
+    assert session.post.call_args[1]["url"] == "http://fakehost.asdf/base/api/2.0/dbfs/put"
+    assert session.post.call_args[1]["json"] == {
+        "path": "dbfs:/tmp/foo/foo/bar",
+        "contents": base64.b64encode(b"yo").decode("ascii"),
+        "overwrite": True,
+    }
+
+
+def test_put_unauthorized(client: DBFSClient, dummy_file_path: str):
+    session = MagicMock()
+
+    unauth_resp = AsyncMock()
+    setattr(type(unauth_resp), "status", PropertyMock(return_value=401))
+
+    session.post.return_value = unauth_resp
+
+    unauth_resp.text.return_value = "bad auth"
+
+    with pytest.raises(ClientError):
+        asyncio.run(client.put(sub_path="foo/bar", full_source_path=dummy_file_path, session=session))

--- a/tests/unit/sync/clients/test_dbfs_client.py
+++ b/tests/unit/sync/clients/test_dbfs_client.py
@@ -30,6 +30,15 @@ def test_delete(client: DBFSClient):
     assert session.post.call_args[1]["json"] == {"path": "dbfs:/tmp/foo/foo/bar"}
 
 
+def test_delete_backslash(client: DBFSClient):
+    session = MagicMock()
+    resp = MagicMock()
+    setattr(type(resp), "status", PropertyMock(return_value=200))
+    session.post.return_value = create_async_with_result(resp)
+    with pytest.raises(ValueError):
+        asyncio.run(client.delete(sub_path="foo\\bar", session=session))
+
+
 def test_delete_no_path(client: DBFSClient):
     session = MagicMock()
     with pytest.raises(ValueError):
@@ -112,6 +121,15 @@ def test_mkdirs(client: DBFSClient):
     assert session.post.call_args[1]["json"] == {"path": "dbfs:/tmp/foo/foo/bar"}
 
 
+def test_mkdirs_backslash(client: DBFSClient):
+    session = MagicMock()
+    resp = MagicMock()
+    setattr(type(resp), "status", PropertyMock(return_value=200))
+    session.post.return_value = create_async_with_result(resp)
+    with pytest.raises(ValueError):
+        asyncio.run(client.mkdirs(sub_path="foo\\bar", session=session))
+
+
 def test_mkdirs_no_path(client: DBFSClient):
     session = MagicMock()
     with pytest.raises(ValueError):
@@ -185,6 +203,16 @@ def test_put(client: DBFSClient, dummy_file_path: str):
         "contents": base64.b64encode(b"yo").decode("ascii"),
         "overwrite": True,
     }
+
+
+def test_put_backslash(client: DBFSClient, dummy_file_path: str):
+    session = MagicMock()
+    resp = MagicMock()
+    setattr(type(resp), "status", PropertyMock(return_value=200))
+    session.post.return_value = create_async_with_result(resp)
+
+    with pytest.raises(ValueError):
+        asyncio.run(client.put(sub_path="foo\\bar", full_source_path=dummy_file_path, session=session))
 
 
 def test_put_no_path(client: DBFSClient, dummy_file_path: str):

--- a/tests/unit/sync/clients/test_get_user.py
+++ b/tests/unit/sync/clients/test_get_user.py
@@ -1,0 +1,24 @@
+from unittest.mock import MagicMock, PropertyMock, patch
+
+from dbx.sync.clients import get_user
+
+
+@patch("dbx.sync.clients.requests")
+def test_get_user(mock_requests, mock_config):
+    resp = MagicMock()
+    setattr(type(resp), "status_code", PropertyMock(return_value=200))
+    user_info = {"userName": "foo"}
+    resp.json.return_value = user_info
+    mock_requests.get.return_value = resp
+    assert get_user(mock_config) == user_info
+    assert resp.json.call_count == 1
+
+
+@patch("dbx.sync.clients.requests")
+def test_get_user_failed(mock_requests, mock_config):
+    resp = MagicMock()
+    setattr(type(resp), "status_code", PropertyMock(return_value=404))
+    resp.json.return_value = {}
+    mock_requests.get.return_value = resp
+    assert get_user(mock_config) is None
+    assert resp.json.call_count == 0

--- a/tests/unit/sync/clients/test_repos_client.py
+++ b/tests/unit/sync/clients/test_repos_client.py
@@ -5,7 +5,7 @@ from unittest.mock import AsyncMock, MagicMock, PropertyMock
 import pytest
 
 from dbx.sync.clients import ClientError, ReposClient
-from tests.unit.sync.utils import mocked_props
+from tests.unit.sync.utils import mocked_props, is_repos_user_agent
 
 
 @pytest.fixture
@@ -40,6 +40,8 @@ def test_delete(client: ReposClient):
     assert session.post.call_args[1]["url"] == "http://fakehost.asdf/base/api/2.0/workspace/delete"
     assert session.post.call_args[1]["json"] == {"path": "/Repos/foo@somewhere.com/my-repo/foo/bar"}
     assert "ssl" not in session.post.call_args[1]
+    assert session.post.call_args[1]["headers"]["Authorization"] == "Bearer fake-token"
+    assert is_repos_user_agent(session.post.call_args[1]["headers"]["user-agent"])
 
 
 def test_delete_secure(client: ReposClient):
@@ -161,6 +163,8 @@ def test_mkdirs(client: ReposClient):
     assert session.post.call_count == 1
     assert session.post.call_args[1]["url"] == "http://fakehost.asdf/base/api/2.0/workspace/mkdirs"
     assert session.post.call_args[1]["json"] == {"path": "/Repos/foo@somewhere.com/my-repo/foo/bar"}
+    assert session.post.call_args[1]["headers"]["Authorization"] == "Bearer fake-token"
+    assert is_repos_user_agent(session.post.call_args[1]["headers"]["user-agent"])
 
 
 def test_mkdirs_backslash(client: ReposClient):
@@ -244,6 +248,8 @@ def test_put(client: ReposClient, dummy_file_path: str):
         == "http://fakehost.asdf/base/api/2.0/workspace-files/import-file/Repos/foo@somewhere.com/my-repo/foo/bar"
     )
     assert session.post.call_args[1]["data"] == b"yo"
+    assert session.post.call_args[1]["headers"]["Authorization"] == "Bearer fake-token"
+    assert is_repos_user_agent(session.post.call_args[1]["headers"]["user-agent"])
 
 
 def test_put_backslash(client: ReposClient, dummy_file_path: str):

--- a/tests/unit/sync/clients/test_repos_client.py
+++ b/tests/unit/sync/clients/test_repos_client.py
@@ -1,0 +1,251 @@
+import asyncio
+from tests.unit.sync.utils import create_async_with_result
+from unittest.mock import AsyncMock, MagicMock, PropertyMock
+
+import pytest
+
+from dbx.sync.clients import ClientError, ReposClient
+
+
+@pytest.fixture
+def client(mock_config):
+    return ReposClient(user="foo@somewhere.com", repo_name="my-repo", config=mock_config)
+
+
+def test_init(client):
+    assert client.api_token == "fake-token"
+    assert client.host == "http://fakehost.asdf/base"
+    assert client.base_path == "/Repos/foo@somewhere.com/my-repo"
+
+
+def test_delete(client: ReposClient):
+    session = MagicMock()
+    resp = MagicMock()
+    setattr(type(resp), "status", PropertyMock(return_value=200))
+    session.post.return_value = create_async_with_result(resp)
+    asyncio.run(client.delete(sub_path="foo/bar", session=session))
+
+    assert session.post.call_count == 1
+    assert session.post.call_args[1]["url"] == "http://fakehost.asdf/base/api/2.0/workspace/delete"
+    assert session.post.call_args[1]["json"] == {"path": "/Repos/foo@somewhere.com/my-repo/foo/bar"}
+
+
+def test_delete_no_path(client: ReposClient):
+    session = MagicMock()
+    with pytest.raises(ValueError):
+        asyncio.run(client.delete(sub_path=None, session=session))
+
+
+def test_delete_recursive(client: ReposClient):
+    session = MagicMock()
+    resp = MagicMock()
+    setattr(type(resp), "status", PropertyMock(return_value=200))
+    session.post.return_value = create_async_with_result(resp)
+    asyncio.run(client.delete(sub_path="foo/bar", session=session, recursive=True))
+
+    assert session.post.call_count == 1
+    assert session.post.call_args[1]["url"] == "http://fakehost.asdf/base/api/2.0/workspace/delete"
+    assert session.post.call_args[1]["json"] == {"path": "/Repos/foo@somewhere.com/my-repo/foo/bar", "recursive": True}
+
+
+def test_delete_rate_limited(client: ReposClient):
+    session = MagicMock()
+
+    rate_limit_resp = MagicMock()
+    setattr(type(rate_limit_resp), "status", PropertyMock(return_value=429))
+
+    success_resp = MagicMock()
+    setattr(type(success_resp), "status", PropertyMock(return_value=200))
+    setattr(type(rate_limit_resp), "headers", PropertyMock(return_value={"Retry-After": None}))
+
+    session.post.side_effect = [create_async_with_result(rate_limit_resp), create_async_with_result(success_resp)]
+
+    asyncio.run(client.delete(sub_path="foo/bar", session=session))
+
+    assert session.post.call_count == 2
+    assert session.post.call_args[1]["url"] == "http://fakehost.asdf/base/api/2.0/workspace/delete"
+    assert session.post.call_args[1]["json"] == {"path": "/Repos/foo@somewhere.com/my-repo/foo/bar"}
+
+
+def test_delete_rate_limited_retry_after(client: ReposClient):
+    session = MagicMock()
+
+    rate_limit_resp = MagicMock()
+    setattr(type(rate_limit_resp), "status", PropertyMock(return_value=429))
+    setattr(type(rate_limit_resp), "headers", PropertyMock(return_value={"Retry-After": 1}))
+
+    success_resp = MagicMock()
+    setattr(type(success_resp), "status", PropertyMock(return_value=200))
+
+    session.post.side_effect = [create_async_with_result(rate_limit_resp), create_async_with_result(success_resp)]
+
+    asyncio.run(client.delete(sub_path="foo/bar", session=session))
+
+    assert session.post.call_count == 2
+    assert session.post.call_args[1]["url"] == "http://fakehost.asdf/base/api/2.0/workspace/delete"
+    assert session.post.call_args[1]["json"] == {"path": "/Repos/foo@somewhere.com/my-repo/foo/bar"}
+
+
+def test_delete_unauthorized(client: ReposClient):
+    session = MagicMock()
+
+    unauth_resp = AsyncMock()
+    setattr(type(unauth_resp), "status", PropertyMock(return_value=401))
+
+    session.post.return_value = unauth_resp
+
+    unauth_resp.text.return_value = "bad auth"
+
+    with pytest.raises(ClientError):
+        asyncio.run(client.delete(sub_path="foo/bar", session=session))
+
+
+def test_mkdirs(client: ReposClient):
+    session = MagicMock()
+    resp = MagicMock()
+    setattr(type(resp), "status", PropertyMock(return_value=200))
+    session.post.return_value = create_async_with_result(resp)
+    asyncio.run(client.mkdirs(sub_path="foo/bar", session=session))
+
+    assert session.post.call_count == 1
+    assert session.post.call_args[1]["url"] == "http://fakehost.asdf/base/api/2.0/workspace/mkdirs"
+    assert session.post.call_args[1]["json"] == {"path": "/Repos/foo@somewhere.com/my-repo/foo/bar"}
+
+
+def test_mkdirs_no_path(client: ReposClient):
+    session = MagicMock()
+    with pytest.raises(ValueError):
+        asyncio.run(client.mkdirs(sub_path=None, session=session))
+
+
+def test_mkdirs_rate_limited(client: ReposClient):
+    session = MagicMock()
+
+    rate_limit_resp = MagicMock()
+    setattr(type(rate_limit_resp), "status", PropertyMock(return_value=429))
+
+    success_resp = MagicMock()
+    setattr(type(success_resp), "status", PropertyMock(return_value=200))
+    setattr(type(rate_limit_resp), "headers", PropertyMock(return_value={"Retry-After": None}))
+
+    session.post.side_effect = [create_async_with_result(rate_limit_resp), create_async_with_result(success_resp)]
+
+    asyncio.run(client.mkdirs(sub_path="foo/bar", session=session))
+
+    assert session.post.call_count == 2
+    assert session.post.call_args[1]["url"] == "http://fakehost.asdf/base/api/2.0/workspace/mkdirs"
+    assert session.post.call_args[1]["json"] == {"path": "/Repos/foo@somewhere.com/my-repo/foo/bar"}
+
+
+def test_mkdirs_rate_limited_retry_after(client: ReposClient):
+    session = MagicMock()
+
+    rate_limit_resp = MagicMock()
+    setattr(type(rate_limit_resp), "status", PropertyMock(return_value=429))
+    setattr(type(rate_limit_resp), "headers", PropertyMock(return_value={"Retry-After": 1}))
+
+    success_resp = MagicMock()
+    setattr(type(success_resp), "status", PropertyMock(return_value=200))
+
+    session.post.side_effect = [create_async_with_result(rate_limit_resp), create_async_with_result(success_resp)]
+
+    asyncio.run(client.mkdirs(sub_path="foo/bar", session=session))
+
+    assert session.post.call_count == 2
+    assert session.post.call_args[1]["url"] == "http://fakehost.asdf/base/api/2.0/workspace/mkdirs"
+    assert session.post.call_args[1]["json"] == {"path": "/Repos/foo@somewhere.com/my-repo/foo/bar"}
+
+
+def test_mkdirs_unauthorized(client: ReposClient):
+    session = MagicMock()
+
+    unauth_resp = AsyncMock()
+    setattr(type(unauth_resp), "status", PropertyMock(return_value=401))
+
+    session.post.return_value = unauth_resp
+
+    unauth_resp.text.return_value = "bad auth"
+
+    with pytest.raises(ClientError):
+        asyncio.run(client.mkdirs(sub_path="foo/bar", session=session))
+
+
+def test_put(client: ReposClient, dummy_file_path: str):
+    session = MagicMock()
+    resp = MagicMock()
+    setattr(type(resp), "status", PropertyMock(return_value=200))
+    session.post.return_value = create_async_with_result(resp)
+
+    asyncio.run(client.put(sub_path="foo/bar", full_source_path=dummy_file_path, session=session))
+
+    assert session.post.call_count == 1
+    assert (
+        session.post.call_args[1]["url"]
+        == "http://fakehost.asdf/base/api/2.0/workspace-files/import-file/Repos/foo@somewhere.com/my-repo/foo/bar"
+    )
+    assert session.post.call_args[1]["data"] == b"yo"
+
+
+def test_put_no_path(client: ReposClient, dummy_file_path: str):
+    session = MagicMock()
+
+    with pytest.raises(ValueError):
+        asyncio.run(client.put(sub_path=None, full_source_path=dummy_file_path, session=session))
+
+
+def test_put_rate_limited(client: ReposClient, dummy_file_path: str):
+    session = MagicMock()
+
+    rate_limit_resp = MagicMock()
+    setattr(type(rate_limit_resp), "status", PropertyMock(return_value=429))
+
+    success_resp = MagicMock()
+    setattr(type(success_resp), "status", PropertyMock(return_value=200))
+    setattr(type(rate_limit_resp), "headers", PropertyMock(return_value={"Retry-After": None}))
+
+    session.post.side_effect = [create_async_with_result(rate_limit_resp), create_async_with_result(success_resp)]
+
+    asyncio.run(client.put(sub_path="foo/bar", full_source_path=dummy_file_path, session=session))
+
+    assert session.post.call_count == 2
+    assert (
+        session.post.call_args[1]["url"]
+        == "http://fakehost.asdf/base/api/2.0/workspace-files/import-file/Repos/foo@somewhere.com/my-repo/foo/bar"
+    )
+    assert session.post.call_args[1]["data"] == b"yo"
+
+
+def test_put_rate_limited_retry_after(client: ReposClient, dummy_file_path: str):
+    session = MagicMock()
+
+    rate_limit_resp = MagicMock()
+    setattr(type(rate_limit_resp), "status", PropertyMock(return_value=429))
+    setattr(type(rate_limit_resp), "headers", PropertyMock(return_value={"Retry-After": 1}))
+
+    success_resp = MagicMock()
+    setattr(type(success_resp), "status", PropertyMock(return_value=200))
+
+    session.post.side_effect = [create_async_with_result(rate_limit_resp), create_async_with_result(success_resp)]
+
+    asyncio.run(client.put(sub_path="foo/bar", full_source_path=dummy_file_path, session=session))
+
+    assert session.post.call_count == 2
+    assert (
+        session.post.call_args[1]["url"]
+        == "http://fakehost.asdf/base/api/2.0/workspace-files/import-file/Repos/foo@somewhere.com/my-repo/foo/bar"
+    )
+    assert session.post.call_args[1]["data"] == b"yo"
+
+
+def test_put_unauthorized(client: ReposClient, dummy_file_path: str):
+    session = MagicMock()
+
+    unauth_resp = AsyncMock()
+    setattr(type(unauth_resp), "status", PropertyMock(return_value=401))
+
+    session.post.return_value = unauth_resp
+
+    unauth_resp.text.return_value = "bad auth"
+
+    with pytest.raises(ClientError):
+        asyncio.run(client.put(sub_path="foo/bar", full_source_path=dummy_file_path, session=session))

--- a/tests/unit/sync/sync/test_dry_run.py
+++ b/tests/unit/sync/sync/test_dry_run.py
@@ -1,0 +1,195 @@
+import asyncio
+import shutil
+from pathlib import Path
+from unittest.mock import AsyncMock
+
+from dbx.commands.sync import create_path_matcher
+from dbx.sync import RemoteSyncer
+
+from tests.unit.sync.utils import temporary_directory
+
+
+def test_single_file_put():
+    """
+    Tests that RemoteSyncer can perform a dry-run when a single file has been created.
+    """
+    client = AsyncMock()
+    client.name = "test"
+    client.base_path = "/test"
+    with temporary_directory() as source, temporary_directory() as state_dir:
+        matcher = create_path_matcher(source=source, includes=None, excludes=None)
+        syncer = RemoteSyncer(
+            client=client,
+            source=source,
+            dry_run=True,
+            includes=None,
+            excludes=None,
+            full_sync=False,
+            state_dir=state_dir,
+            matcher=matcher,
+        )
+
+        # initially no files
+        op_count = asyncio.run(syncer.incremental_copy())
+        assert op_count == 0
+        assert client.delete.call_count == 0
+        assert client.mkdirs.call_count == 0
+        assert client.put.call_count == 0
+
+        # create a file to sync
+        (Path(source) / "foo").touch()
+
+        # sync the file.  because it's a dry run we don't copy anything.
+        assert asyncio.run(syncer.incremental_copy()) == 1
+        assert client.delete.call_count == 0
+        assert client.mkdirs.call_count == 0
+        assert client.put.call_count == 0
+
+
+def test_mkdir_put():
+    """
+    Tests that RemoteSyncer can perform a dry-run when a single file and directory have been created.
+    """
+    client = AsyncMock()
+    client.name = "test"
+    client.base_path = "/test"
+    with temporary_directory() as source, temporary_directory() as state_dir:
+        matcher = create_path_matcher(source=source, includes=None, excludes=None)
+        syncer = RemoteSyncer(
+            client=client,
+            source=source,
+            dry_run=True,
+            includes=None,
+            excludes=None,
+            full_sync=False,
+            state_dir=state_dir,
+            matcher=matcher,
+        )
+
+        # initially no files
+        op_count = asyncio.run(syncer.incremental_copy())
+        assert op_count == 0
+        assert client.delete.call_count == 0
+        assert client.mkdirs.call_count == 0
+        assert client.put.call_count == 0
+
+        # create a file to sync
+        (Path(source) / "foo").mkdir()
+        (Path(source) / "foo" / "bar").touch()
+
+        # sync the file and dir.  because it's a dry run we don't copy anything.
+        assert asyncio.run(syncer.incremental_copy()) == 2
+        assert client.delete.call_count == 0
+        assert client.mkdirs.call_count == 0
+        assert client.put.call_count == 0
+
+
+def test_delete():
+    """
+    Tests that RemoteSyncer can perform a dry-run when a directory and file are deleted.
+    """
+    client = AsyncMock()
+    client.name = "test"
+    client.base_path = "/test"
+    with temporary_directory() as source, temporary_directory() as state_dir:
+        matcher = create_path_matcher(source=source, includes=None, excludes=None)
+
+        # first syncer does not do dry run
+        syncer = RemoteSyncer(
+            client=client,
+            source=source,
+            dry_run=False,
+            includes=None,
+            excludes=None,
+            full_sync=False,
+            state_dir=state_dir,
+            matcher=matcher,
+        )
+
+        # initially no files
+        op_count = asyncio.run(syncer.incremental_copy())
+        assert op_count == 0
+        assert client.delete.call_count == 0
+        assert client.mkdirs.call_count == 0
+        assert client.put.call_count == 0
+
+        # create a file to sync
+        (Path(source) / "foo").mkdir()
+        (Path(source) / "foo" / "bar").touch()
+
+        # sync the file.  because it's a dry run we don't copy anything.
+        assert asyncio.run(syncer.incremental_copy()) == 2
+        assert client.delete.call_count == 0
+        assert client.mkdirs.call_count == 1
+        assert client.put.call_count == 1
+
+        # sync again.  should be nothing else to sync.
+        assert asyncio.run(syncer.incremental_copy()) == 0
+
+        # second syncer does do dry run
+        syncer = RemoteSyncer(
+            client=client,
+            source=source,
+            dry_run=True,
+            includes=None,
+            excludes=None,
+            full_sync=False,
+            state_dir=state_dir,
+            matcher=matcher,
+        )
+
+        # delete the directory and its file
+        shutil.rmtree(Path(source) / "foo")
+
+        # sync the file.  because it's a dry run we don't delete anything for real.
+        assert asyncio.run(syncer.incremental_copy()) == 2
+        assert client.delete.call_count == 0
+        assert client.mkdirs.call_count == 1
+        assert client.put.call_count == 1
+
+
+def test_single_file_put_twice():
+    """
+    Tests that RemoteSyncer can perform a dry-run when a single file has been created and then modified.
+    """
+    client = AsyncMock()
+    client.name = "test"
+    client.base_path = "/test"
+    with temporary_directory() as source, temporary_directory() as state_dir:
+        matcher = create_path_matcher(source=source, includes=None, excludes=None)
+        syncer = RemoteSyncer(
+            client=client,
+            source=source,
+            dry_run=True,
+            includes=None,
+            excludes=None,
+            full_sync=False,
+            state_dir=state_dir,
+            matcher=matcher,
+        )
+
+        # initially no files
+        op_count = asyncio.run(syncer.incremental_copy())
+        assert op_count == 0
+        assert client.delete.call_count == 0
+        assert client.mkdirs.call_count == 0
+        assert client.put.call_count == 0
+
+        # create a file to sync
+        (Path(source) / "foo").touch()
+
+        # sync the file.  because it's a dry run we don't copy anything.
+        assert asyncio.run(syncer.incremental_copy()) == 1
+        assert client.delete.call_count == 0
+        assert client.mkdirs.call_count == 0
+        assert client.put.call_count == 0
+
+        # modify if
+        with open(Path(source) / "foo", "w") as f:
+            f.write("blah")
+
+        # sync the file.  because it's a dry run we don't copy anything.
+        assert asyncio.run(syncer.incremental_copy()) == 1
+        assert client.delete.call_count == 0
+        assert client.mkdirs.call_count == 0
+        assert client.put.call_count == 0

--- a/tests/unit/sync/sync/test_dry_run.py
+++ b/tests/unit/sync/sync/test_dry_run.py
@@ -30,7 +30,7 @@ def test_single_file_put():
         )
 
         # initially no files
-        op_count = asyncio.run(syncer.incremental_copy())
+        op_count = syncer.incremental_copy()
         assert op_count == 0
         assert client.delete.call_count == 0
         assert client.mkdirs.call_count == 0
@@ -40,7 +40,7 @@ def test_single_file_put():
         (Path(source) / "foo").touch()
 
         # sync the file.  because it's a dry run we don't copy anything.
-        assert asyncio.run(syncer.incremental_copy()) == 1
+        assert syncer.incremental_copy() == 1
         assert client.delete.call_count == 0
         assert client.mkdirs.call_count == 0
         assert client.put.call_count == 0
@@ -67,7 +67,7 @@ def test_mkdir_put():
         )
 
         # initially no files
-        op_count = asyncio.run(syncer.incremental_copy())
+        op_count = syncer.incremental_copy()
         assert op_count == 0
         assert client.delete.call_count == 0
         assert client.mkdirs.call_count == 0
@@ -78,7 +78,7 @@ def test_mkdir_put():
         (Path(source) / "foo" / "bar").touch()
 
         # sync the file and dir.  because it's a dry run we don't copy anything.
-        assert asyncio.run(syncer.incremental_copy()) == 2
+        assert syncer.incremental_copy() == 2
         assert client.delete.call_count == 0
         assert client.mkdirs.call_count == 0
         assert client.put.call_count == 0
@@ -107,7 +107,7 @@ def test_delete():
         )
 
         # initially no files
-        op_count = asyncio.run(syncer.incremental_copy())
+        op_count = syncer.incremental_copy()
         assert op_count == 0
         assert client.delete.call_count == 0
         assert client.mkdirs.call_count == 0
@@ -118,13 +118,13 @@ def test_delete():
         (Path(source) / "foo" / "bar").touch()
 
         # sync the file.  because it's a dry run we don't copy anything.
-        assert asyncio.run(syncer.incremental_copy()) == 2
+        assert syncer.incremental_copy() == 2
         assert client.delete.call_count == 0
         assert client.mkdirs.call_count == 1
         assert client.put.call_count == 1
 
         # sync again.  should be nothing else to sync.
-        assert asyncio.run(syncer.incremental_copy()) == 0
+        assert syncer.incremental_copy() == 0
 
         # second syncer does do dry run
         syncer = RemoteSyncer(
@@ -142,7 +142,7 @@ def test_delete():
         shutil.rmtree(Path(source) / "foo")
 
         # sync the file.  because it's a dry run we don't delete anything for real.
-        assert asyncio.run(syncer.incremental_copy()) == 2
+        assert syncer.incremental_copy() == 2
         assert client.delete.call_count == 0
         assert client.mkdirs.call_count == 1
         assert client.put.call_count == 1
@@ -169,7 +169,7 @@ def test_single_file_put_twice():
         )
 
         # initially no files
-        op_count = asyncio.run(syncer.incremental_copy())
+        op_count = syncer.incremental_copy()
         assert op_count == 0
         assert client.delete.call_count == 0
         assert client.mkdirs.call_count == 0
@@ -179,7 +179,7 @@ def test_single_file_put_twice():
         (Path(source) / "foo").touch()
 
         # sync the file.  because it's a dry run we don't copy anything.
-        assert asyncio.run(syncer.incremental_copy()) == 1
+        assert syncer.incremental_copy() == 1
         assert client.delete.call_count == 0
         assert client.mkdirs.call_count == 0
         assert client.put.call_count == 0
@@ -189,7 +189,7 @@ def test_single_file_put_twice():
             f.write("blah")
 
         # sync the file.  because it's a dry run we don't copy anything.
-        assert asyncio.run(syncer.incremental_copy()) == 1
+        assert syncer.incremental_copy() == 1
         assert client.delete.call_count == 0
         assert client.mkdirs.call_count == 0
         assert client.put.call_count == 0

--- a/tests/unit/sync/sync/test_filtering.py
+++ b/tests/unit/sync/sync/test_filtering.py
@@ -1,0 +1,225 @@
+import asyncio
+import logging
+import os
+from pathlib import Path
+from unittest.mock import AsyncMock
+
+from dbx.commands.sync import create_path_matcher
+from dbx.sync import RemoteSyncer
+
+from tests.unit.sync.utils import temporary_directory
+
+logger = logging.getLogger(__name__)
+
+
+def test_include():
+    """
+    Tests that includes can be used to limit which directories are synced over.
+    """
+
+    client = AsyncMock()
+    client.name = "test"
+    client.base_path = "/test"
+    with temporary_directory() as source, temporary_directory() as state_dir:
+        includes = ["foo"]
+        excludes = None
+        matcher = create_path_matcher(source=source, includes=includes, excludes=excludes)
+        syncer = RemoteSyncer(
+            client=client,
+            source=source,
+            dry_run=False,
+            includes=includes,
+            excludes=excludes,
+            full_sync=False,
+            state_dir=state_dir,
+            matcher=matcher,
+        )
+
+        # create a dir and file to sync
+        (Path(source) / "foo").mkdir()
+        (Path(source) / "foo" / "bar").touch()
+
+        # and some dirs and files that should be ignored
+        (Path(source) / "baz").touch()
+        (Path(source) / "bar").mkdir()
+        (Path(source) / "bar" / "baz").touch()
+
+        parent = AsyncMock()
+        parent.attach_mock(client, "client")
+
+        # sync the file and dir
+        assert asyncio.run(syncer.incremental_copy()) == 2
+        assert client.delete.call_count == 0
+        assert client.mkdirs.call_count == 1
+        assert client.put.call_count == 1
+        assert parent.mock_calls[0][0] == "client.mkdirs"
+        assert parent.mock_calls[0][1] == ("foo",)
+        assert parent.mock_calls[1][0] == "client.put"
+        assert parent.mock_calls[1][1] == ("foo/bar", os.path.join(source, "foo", "bar"))
+
+        # syncing again should result in no additional operations
+        assert asyncio.run(syncer.incremental_copy()) == 0
+        assert client.delete.call_count == 0
+        assert client.mkdirs.call_count == 1
+        assert client.put.call_count == 1
+
+
+def test_default_ignore_git():
+    """
+    Tests that a .git directory is ignored by default.
+    """
+
+    client = AsyncMock()
+    client.name = "test"
+    client.base_path = "/test"
+    with temporary_directory() as source, temporary_directory() as state_dir:
+        includes = None
+        excludes = None
+        matcher = create_path_matcher(source=source, includes=includes, excludes=excludes)
+        syncer = RemoteSyncer(
+            client=client,
+            source=source,
+            dry_run=False,
+            includes=includes,
+            excludes=excludes,
+            full_sync=False,
+            state_dir=state_dir,
+            matcher=matcher,
+        )
+
+        # create a dir and file to sync
+        (Path(source) / "foo").mkdir()
+        (Path(source) / "foo" / "bar").touch()
+
+        # and some dirs and files that should be ignored
+        (Path(source) / ".git").mkdir()
+        (Path(source) / ".git" / "foo").touch()
+
+        parent = AsyncMock()
+        parent.attach_mock(client, "client")
+
+        # sync the file and dir
+        assert asyncio.run(syncer.incremental_copy()) == 2
+        assert client.delete.call_count == 0
+        assert client.mkdirs.call_count == 1
+        assert client.put.call_count == 1
+        assert parent.mock_calls[0][0] == "client.mkdirs"
+        assert parent.mock_calls[0][1] == ("foo",)
+        assert parent.mock_calls[1][0] == "client.put"
+        assert parent.mock_calls[1][1] == ("foo/bar", os.path.join(source, "foo", "bar"))
+
+        # syncing again should result in no additional operations
+        assert asyncio.run(syncer.incremental_copy()) == 0
+        assert client.delete.call_count == 0
+        assert client.mkdirs.call_count == 1
+        assert client.put.call_count == 1
+
+
+def test_exclude():
+    """
+    Tests that excludes can be used to prevent certain directories from being synced over.
+    """
+
+    client = AsyncMock()
+    client.name = "test"
+    client.base_path = "/test"
+    with temporary_directory() as source, temporary_directory() as state_dir:
+        includes = None
+        excludes = ["baz"]
+        matcher = create_path_matcher(source=source, includes=includes, excludes=excludes)
+        syncer = RemoteSyncer(
+            client=client,
+            source=source,
+            dry_run=False,
+            includes=includes,
+            excludes=excludes,
+            full_sync=False,
+            state_dir=state_dir,
+            matcher=matcher,
+        )
+
+        # create a dir and file to sync
+        (Path(source) / "foo").mkdir()
+        (Path(source) / "foo" / "bar").touch()
+
+        # and some dirs and files that should be ignored
+        (Path(source) / "baz").mkdir()
+        (Path(source) / "baz" / "bar").touch()
+
+        parent = AsyncMock()
+        parent.attach_mock(client, "client")
+
+        # sync the file and dir
+        assert asyncio.run(syncer.incremental_copy()) == 2
+        assert client.delete.call_count == 0
+        assert client.mkdirs.call_count == 1
+        assert client.put.call_count == 1
+        assert parent.mock_calls[0][0] == "client.mkdirs"
+        assert parent.mock_calls[0][1] == ("foo",)
+        assert parent.mock_calls[1][0] == "client.put"
+        assert parent.mock_calls[1][1] == ("foo/bar", os.path.join(source, "foo", "bar"))
+
+        # syncing again should result in no additional operations
+        assert asyncio.run(syncer.incremental_copy()) == 0
+        assert client.delete.call_count == 0
+        assert client.mkdirs.call_count == 1
+        assert client.put.call_count == 1
+
+
+def test_include_deeply_nested():
+    """
+    Tests that includes can be used to limit which directories are synced over and that it works
+    with deeply nested files.
+    """
+
+    client = AsyncMock()
+    client.name = "test"
+    client.base_path = "/test"
+    with temporary_directory() as source, temporary_directory() as state_dir:
+        includes = ["foo/bar/baz"]
+        excludes = None
+        matcher = create_path_matcher(source=source, includes=includes, excludes=excludes)
+        syncer = RemoteSyncer(
+            client=client,
+            source=source,
+            dry_run=False,
+            includes=includes,
+            excludes=excludes,
+            full_sync=False,
+            state_dir=state_dir,
+            matcher=matcher,
+        )
+
+        # create a dir and file to sync
+        (Path(source) / "foo").mkdir()
+        (Path(source) / "foo" / "bar").mkdir()
+        (Path(source) / "foo" / "bar" / "baz").mkdir()
+        (Path(source) / "foo" / "bar" / "baz" / "bop").touch()
+
+        # and some dirs and files that should be ignored
+        (Path(source) / "baz").touch()
+        (Path(source) / "bar").mkdir()
+        (Path(source) / "bar" / "baz").touch()
+
+        parent = AsyncMock()
+        parent.attach_mock(client, "client")
+
+        # sync the file and dir
+        assert asyncio.run(syncer.incremental_copy()) == 4
+        assert client.delete.call_count == 0
+        assert client.mkdirs.call_count == 3
+        assert client.put.call_count == 1
+        assert parent.mock_calls[0][0] == "client.mkdirs"
+        assert parent.mock_calls[0][1] == ("foo",)
+        assert parent.mock_calls[1][0] == "client.mkdirs"
+        assert parent.mock_calls[1][1] == ("foo/bar",)
+        assert parent.mock_calls[2][0] == "client.mkdirs"
+        assert parent.mock_calls[2][1] == ("foo/bar/baz",)
+        assert parent.mock_calls[3][0] == "client.put"
+        assert parent.mock_calls[3][1] == ("foo/bar/baz/bop", os.path.join(source, "foo", "bar", "baz", "bop"))
+
+        # syncing again should result in no additional operations
+        assert asyncio.run(syncer.incremental_copy()) == 0
+        assert client.delete.call_count == 0
+        assert client.mkdirs.call_count == 3
+        assert client.put.call_count == 1

--- a/tests/unit/sync/sync/test_filtering.py
+++ b/tests/unit/sync/sync/test_filtering.py
@@ -48,7 +48,7 @@ def test_include():
         parent.attach_mock(client, "client")
 
         # sync the file and dir
-        assert asyncio.run(syncer.incremental_copy()) == 2
+        assert syncer.incremental_copy() == 2
         assert client.delete.call_count == 0
         assert client.mkdirs.call_count == 1
         assert client.put.call_count == 1
@@ -58,7 +58,7 @@ def test_include():
         assert parent.mock_calls[1][1] == ("foo/bar", os.path.join(source, "foo", "bar"))
 
         # syncing again should result in no additional operations
-        assert asyncio.run(syncer.incremental_copy()) == 0
+        assert syncer.incremental_copy() == 0
         assert client.delete.call_count == 0
         assert client.mkdirs.call_count == 1
         assert client.put.call_count == 1
@@ -99,7 +99,7 @@ def test_default_ignore_git():
         parent.attach_mock(client, "client")
 
         # sync the file and dir
-        assert asyncio.run(syncer.incremental_copy()) == 2
+        assert syncer.incremental_copy() == 2
         assert client.delete.call_count == 0
         assert client.mkdirs.call_count == 1
         assert client.put.call_count == 1
@@ -109,7 +109,7 @@ def test_default_ignore_git():
         assert parent.mock_calls[1][1] == ("foo/bar", os.path.join(source, "foo", "bar"))
 
         # syncing again should result in no additional operations
-        assert asyncio.run(syncer.incremental_copy()) == 0
+        assert syncer.incremental_copy() == 0
         assert client.delete.call_count == 0
         assert client.mkdirs.call_count == 1
         assert client.put.call_count == 1
@@ -150,7 +150,7 @@ def test_exclude():
         parent.attach_mock(client, "client")
 
         # sync the file and dir
-        assert asyncio.run(syncer.incremental_copy()) == 2
+        assert syncer.incremental_copy() == 2
         assert client.delete.call_count == 0
         assert client.mkdirs.call_count == 1
         assert client.put.call_count == 1
@@ -160,7 +160,7 @@ def test_exclude():
         assert parent.mock_calls[1][1] == ("foo/bar", os.path.join(source, "foo", "bar"))
 
         # syncing again should result in no additional operations
-        assert asyncio.run(syncer.incremental_copy()) == 0
+        assert syncer.incremental_copy() == 0
         assert client.delete.call_count == 0
         assert client.mkdirs.call_count == 1
         assert client.put.call_count == 1
@@ -205,7 +205,7 @@ def test_include_deeply_nested():
         parent.attach_mock(client, "client")
 
         # sync the file and dir
-        assert asyncio.run(syncer.incremental_copy()) == 4
+        assert syncer.incremental_copy() == 4
         assert client.delete.call_count == 0
         assert client.mkdirs.call_count == 3
         assert client.put.call_count == 1
@@ -219,7 +219,7 @@ def test_include_deeply_nested():
         assert parent.mock_calls[3][1] == ("foo/bar/baz/bop", os.path.join(source, "foo", "bar", "baz", "bop"))
 
         # syncing again should result in no additional operations
-        assert asyncio.run(syncer.incremental_copy()) == 0
+        assert syncer.incremental_copy() == 0
         assert client.delete.call_count == 0
         assert client.mkdirs.call_count == 3
         assert client.put.call_count == 1

--- a/tests/unit/sync/sync/test_full_sync.py
+++ b/tests/unit/sync/sync/test_full_sync.py
@@ -1,0 +1,229 @@
+import asyncio
+import os
+from pathlib import Path
+from unittest.mock import AsyncMock
+
+from dbx.commands.sync import create_path_matcher
+from dbx.sync import RemoteSyncer
+
+from tests.unit.sync.utils import temporary_directory
+
+
+def test_initial_full_sync():
+    """
+    Tests that RemoteSyncer can perform a full sync under the scenario where it is the first time
+    encountering the files.
+    """
+
+    client = AsyncMock()
+    client.name = "test"
+    client.base_path = "/test"
+    with temporary_directory() as source, temporary_directory() as state_dir:
+        matcher = create_path_matcher(source=source, includes=None, excludes=None)
+        syncer = RemoteSyncer(
+            client=client,
+            source=source,
+            dry_run=False,
+            includes=None,
+            excludes=None,
+            full_sync=True,
+            state_dir=state_dir,
+            matcher=matcher,
+        )
+
+        # initially no files
+        op_count = asyncio.run(syncer.incremental_copy())
+        assert op_count == 0
+        assert client.delete.call_count == 0
+        assert client.mkdirs.call_count == 0
+        assert client.put.call_count == 0
+
+        # create a directory and a file in that directory
+        (Path(source) / "foo").mkdir()
+        (Path(source) / "foo" / "bar").touch()
+
+        parent = AsyncMock()
+        parent.attach_mock(client, "client")
+
+        # directory and file should be created in the proper order
+        assert asyncio.run(syncer.incremental_copy()) == 2
+        assert client.delete.call_count == 0
+        assert client.mkdirs.call_count == 1
+        assert client.put.call_count == 1
+        assert parent.mock_calls[0][0] == "client.mkdirs"
+        assert parent.mock_calls[0][1] == ("foo",)
+        assert parent.mock_calls[1][0] == "client.put"
+        assert parent.mock_calls[1][1] == ("foo/bar", os.path.join(source, "foo", "bar"))
+
+        # sync again.  no more ops.
+        assert asyncio.run(syncer.incremental_copy()) == 0
+        assert client.delete.call_count == 0
+        assert client.mkdirs.call_count == 1
+        assert client.put.call_count == 1
+
+
+def test_full_sync_after_initial_sync():
+    """
+    Tests that RemoteSyncer can perform a full sync after the files have previously been synced.
+    """
+
+    client = AsyncMock()
+    client.name = "test"
+    client.base_path = "/test"
+    with temporary_directory() as source, temporary_directory() as state_dir:
+        matcher = create_path_matcher(source=source, includes=None, excludes=None)
+        syncer = RemoteSyncer(
+            client=client,
+            source=source,
+            dry_run=False,
+            includes=None,
+            excludes=None,
+            full_sync=False,
+            state_dir=state_dir,
+            matcher=matcher,
+        )
+
+        # initially no files
+        op_count = asyncio.run(syncer.incremental_copy())
+        assert op_count == 0
+        assert client.delete.call_count == 0
+        assert client.mkdirs.call_count == 0
+        assert client.put.call_count == 0
+
+        # create a directory and a file in that directory
+        (Path(source) / "foo").mkdir()
+        (Path(source) / "foo" / "bar").touch()
+
+        parent = AsyncMock()
+        parent.attach_mock(client, "client")
+
+        # directory and file should be created in the proper order
+        assert asyncio.run(syncer.incremental_copy()) == 2
+        assert client.delete.call_count == 0
+        assert client.mkdirs.call_count == 1
+        assert client.put.call_count == 1
+        assert parent.mock_calls[0][0] == "client.mkdirs"
+        assert parent.mock_calls[0][1] == ("foo",)
+        assert parent.mock_calls[1][0] == "client.put"
+        assert parent.mock_calls[1][1] == ("foo/bar", os.path.join(source, "foo", "bar"))
+
+        # sync again.  no more ops.
+        assert asyncio.run(syncer.incremental_copy()) == 0
+        assert client.delete.call_count == 0
+        assert client.mkdirs.call_count == 1
+        assert client.put.call_count == 1
+
+        # creating a new syncer should result in no more ops because the state dir is used
+        syncer = RemoteSyncer(
+            client=client,
+            source=source,
+            dry_run=False,
+            includes=None,
+            excludes=None,
+            full_sync=False,
+            state_dir=state_dir,
+            matcher=matcher,
+        )
+
+        # sync again.  no more ops.
+        assert asyncio.run(syncer.incremental_copy()) == 0
+        assert client.delete.call_count == 0
+        assert client.mkdirs.call_count == 1
+        assert client.put.call_count == 1
+
+        # but, if we set full sync, then the initial sync will repeat the operations again
+        syncer = RemoteSyncer(
+            client=client,
+            source=source,
+            dry_run=False,
+            includes=None,
+            excludes=None,
+            full_sync=True,
+            state_dir=state_dir,
+            matcher=matcher,
+        )
+
+        parent = AsyncMock()
+        parent.attach_mock(client, "client")
+
+        # sync again.  same operations repeated again.
+        assert asyncio.run(syncer.incremental_copy()) == 2
+        assert client.delete.call_count == 0
+        assert client.mkdirs.call_count == 2
+        assert client.put.call_count == 2
+        assert parent.mock_calls[0][0] == "client.mkdirs"
+        assert parent.mock_calls[0][1] == ("foo",)
+        assert parent.mock_calls[1][0] == "client.put"
+        assert parent.mock_calls[1][1] == ("foo/bar", os.path.join(source, "foo", "bar"))
+
+
+def test_dry_run_full_sync_after_initial_sync():
+    """
+    Tests that RemoteSyncer can perform a dry-run of a full sync after an initial sync.
+    """
+    client = AsyncMock()
+    client.name = "test"
+    client.base_path = "/test"
+    with temporary_directory() as source, temporary_directory() as state_dir:
+        matcher = create_path_matcher(source=source, includes=None, excludes=None)
+        syncer = RemoteSyncer(
+            client=client,
+            source=source,
+            dry_run=False,
+            includes=None,
+            excludes=None,
+            full_sync=False,
+            state_dir=state_dir,
+            matcher=matcher,
+        )
+
+        # initially no files
+        op_count = asyncio.run(syncer.incremental_copy())
+        assert op_count == 0
+        assert client.delete.call_count == 0
+        assert client.mkdirs.call_count == 0
+        assert client.put.call_count == 0
+
+        # create a directory and a file in that directory
+        (Path(source) / "foo").mkdir()
+        (Path(source) / "foo" / "bar").touch()
+
+        parent = AsyncMock()
+        parent.attach_mock(client, "client")
+
+        # directory and file should be created in the proper order
+        assert asyncio.run(syncer.incremental_copy()) == 2
+        assert client.delete.call_count == 0
+        assert client.mkdirs.call_count == 1
+        assert client.put.call_count == 1
+        assert parent.mock_calls[0][0] == "client.mkdirs"
+        assert parent.mock_calls[0][1] == ("foo",)
+        assert parent.mock_calls[1][0] == "client.put"
+        assert parent.mock_calls[1][1] == ("foo/bar", os.path.join(source, "foo", "bar"))
+
+        # sync again.  no more ops.
+        assert asyncio.run(syncer.incremental_copy()) == 0
+        assert client.delete.call_count == 0
+        assert client.mkdirs.call_count == 1
+        assert client.put.call_count == 1
+
+        # run full sync in dry run mode.  no operations should happen.
+        syncer = RemoteSyncer(
+            client=client,
+            source=source,
+            dry_run=True,
+            includes=None,
+            excludes=None,
+            full_sync=True,
+            state_dir=state_dir,
+            matcher=matcher,
+        )
+
+        parent = AsyncMock()
+        parent.attach_mock(client, "client")
+
+        # sync again.  no additional operations should be made.
+        assert asyncio.run(syncer.incremental_copy()) == 2
+        assert client.delete.call_count == 0
+        assert client.mkdirs.call_count == 1
+        assert client.put.call_count == 1

--- a/tests/unit/sync/sync/test_full_sync.py
+++ b/tests/unit/sync/sync/test_full_sync.py
@@ -32,7 +32,7 @@ def test_initial_full_sync():
         )
 
         # initially no files
-        op_count = asyncio.run(syncer.incremental_copy())
+        op_count = syncer.incremental_copy()
         assert op_count == 0
         assert client.delete.call_count == 0
         assert client.mkdirs.call_count == 0
@@ -46,7 +46,7 @@ def test_initial_full_sync():
         parent.attach_mock(client, "client")
 
         # directory and file should be created in the proper order
-        assert asyncio.run(syncer.incremental_copy()) == 2
+        assert syncer.incremental_copy() == 2
         assert client.delete.call_count == 0
         assert client.mkdirs.call_count == 1
         assert client.put.call_count == 1
@@ -56,7 +56,7 @@ def test_initial_full_sync():
         assert parent.mock_calls[1][1] == ("foo/bar", os.path.join(source, "foo", "bar"))
 
         # sync again.  no more ops.
-        assert asyncio.run(syncer.incremental_copy()) == 0
+        assert syncer.incremental_copy() == 0
         assert client.delete.call_count == 0
         assert client.mkdirs.call_count == 1
         assert client.put.call_count == 1
@@ -84,7 +84,7 @@ def test_full_sync_after_initial_sync():
         )
 
         # initially no files
-        op_count = asyncio.run(syncer.incremental_copy())
+        op_count = syncer.incremental_copy()
         assert op_count == 0
         assert client.delete.call_count == 0
         assert client.mkdirs.call_count == 0
@@ -98,7 +98,7 @@ def test_full_sync_after_initial_sync():
         parent.attach_mock(client, "client")
 
         # directory and file should be created in the proper order
-        assert asyncio.run(syncer.incremental_copy()) == 2
+        assert syncer.incremental_copy() == 2
         assert client.delete.call_count == 0
         assert client.mkdirs.call_count == 1
         assert client.put.call_count == 1
@@ -108,7 +108,7 @@ def test_full_sync_after_initial_sync():
         assert parent.mock_calls[1][1] == ("foo/bar", os.path.join(source, "foo", "bar"))
 
         # sync again.  no more ops.
-        assert asyncio.run(syncer.incremental_copy()) == 0
+        assert syncer.incremental_copy() == 0
         assert client.delete.call_count == 0
         assert client.mkdirs.call_count == 1
         assert client.put.call_count == 1
@@ -126,7 +126,7 @@ def test_full_sync_after_initial_sync():
         )
 
         # sync again.  no more ops.
-        assert asyncio.run(syncer.incremental_copy()) == 0
+        assert syncer.incremental_copy() == 0
         assert client.delete.call_count == 0
         assert client.mkdirs.call_count == 1
         assert client.put.call_count == 1
@@ -147,7 +147,7 @@ def test_full_sync_after_initial_sync():
         parent.attach_mock(client, "client")
 
         # sync again.  same operations repeated again.
-        assert asyncio.run(syncer.incremental_copy()) == 2
+        assert syncer.incremental_copy() == 2
         assert client.delete.call_count == 0
         assert client.mkdirs.call_count == 2
         assert client.put.call_count == 2
@@ -178,7 +178,7 @@ def test_dry_run_full_sync_after_initial_sync():
         )
 
         # initially no files
-        op_count = asyncio.run(syncer.incremental_copy())
+        op_count = syncer.incremental_copy()
         assert op_count == 0
         assert client.delete.call_count == 0
         assert client.mkdirs.call_count == 0
@@ -192,7 +192,7 @@ def test_dry_run_full_sync_after_initial_sync():
         parent.attach_mock(client, "client")
 
         # directory and file should be created in the proper order
-        assert asyncio.run(syncer.incremental_copy()) == 2
+        assert syncer.incremental_copy() == 2
         assert client.delete.call_count == 0
         assert client.mkdirs.call_count == 1
         assert client.put.call_count == 1
@@ -202,7 +202,7 @@ def test_dry_run_full_sync_after_initial_sync():
         assert parent.mock_calls[1][1] == ("foo/bar", os.path.join(source, "foo", "bar"))
 
         # sync again.  no more ops.
-        assert asyncio.run(syncer.incremental_copy()) == 0
+        assert syncer.incremental_copy() == 0
         assert client.delete.call_count == 0
         assert client.mkdirs.call_count == 1
         assert client.put.call_count == 1
@@ -223,7 +223,7 @@ def test_dry_run_full_sync_after_initial_sync():
         parent.attach_mock(client, "client")
 
         # sync again.  no additional operations should be made.
-        assert asyncio.run(syncer.incremental_copy()) == 2
+        assert syncer.incremental_copy() == 2
         assert client.delete.call_count == 0
         assert client.mkdirs.call_count == 1
         assert client.put.call_count == 1

--- a/tests/unit/sync/sync/test_many_files.py
+++ b/tests/unit/sync/sync/test_many_files.py
@@ -1,0 +1,137 @@
+import asyncio
+import os
+import shutil
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from unittest.mock import AsyncMock
+
+from dbx.commands.sync import create_path_matcher
+from dbx.sync import RemoteSyncer
+
+from tests.unit.sync.utils import temporary_directory
+
+
+def test_syncing_many_files():
+    """
+    Tests that RemoteSyncer can be used to sync many files with deeply nested folders.
+    """
+
+    client = AsyncMock()
+    client.name = "test"
+    client.base_path = "/test"
+    with temporary_directory() as source, temporary_directory() as state_dir:
+        matcher = create_path_matcher(source=source, includes=None, excludes=None)
+        syncer = RemoteSyncer(
+            client=client,
+            source=source,
+            dry_run=False,
+            includes=None,
+            excludes=None,
+            full_sync=False,
+            state_dir=state_dir,
+            matcher=matcher,
+        )
+
+        # initially no files
+        op_count = asyncio.run(syncer.incremental_copy())
+        assert op_count == 0
+        assert client.delete.call_count == 0
+        assert client.mkdirs.call_count == 0
+        assert client.put.call_count == 0
+
+        # create a directory and a file in that directory
+        (Path(source) / "foo").mkdir()
+        (Path(source) / "foo" / "bar").mkdir()
+        (Path(source) / "foo" / "bar" / "baz1").touch()
+        (Path(source) / "foo" / "bar" / "baz2").touch()
+        (Path(source) / "foo" / "bar" / "baz3").touch()
+        (Path(source) / "bar").mkdir()
+        (Path(source) / "baz").mkdir()
+        (Path(source) / "baz" / "foo1").touch()
+        (Path(source) / "baz" / "foo2").touch()
+        (Path(source) / "baz" / "foo3").touch()
+
+        parent = AsyncMock()
+        parent.attach_mock(client, "client")
+
+        # directory and file should be created in the proper order
+        assert asyncio.run(syncer.incremental_copy()) == 10
+        assert client.delete.call_count == 0
+        assert client.mkdirs.call_count == 4
+        assert client.put.call_count == 6
+
+        mock_calls = iter(parent.mock_calls)
+        next_call = next(mock_calls)
+        assert next_call[0] == "client.mkdirs"
+        assert next_call[1] == ("bar",)
+        next_call = next(mock_calls)
+        assert next_call[0] == "client.mkdirs"
+        assert next_call[1] == ("baz",)
+        next_call = next(mock_calls)
+        assert next_call[0] == "client.mkdirs"
+        assert next_call[1] == ("foo",)
+        next_call = next(mock_calls)
+        assert next_call[0] == "client.mkdirs"
+        assert next_call[1] == ("foo/bar",)
+        next_call = next(mock_calls)
+        assert next_call[0] == "client.put"
+        assert next_call[1] == ("baz/foo1", os.path.join(source, "baz", "foo1"))
+        next_call = next(mock_calls)
+        assert next_call[0] == "client.put"
+        assert next_call[1] == ("baz/foo2", os.path.join(source, "baz", "foo2"))
+        next_call = next(mock_calls)
+        assert next_call[0] == "client.put"
+        assert next_call[1] == ("baz/foo3", os.path.join(source, "baz", "foo3"))
+        next_call = next(mock_calls)
+        assert next_call[0] == "client.put"
+        assert next_call[1] == ("foo/bar/baz1", os.path.join(source, "foo", "bar", "baz1"))
+        next_call = next(mock_calls)
+        assert next_call[0] == "client.put"
+        assert next_call[1] == ("foo/bar/baz2", os.path.join(source, "foo", "bar", "baz2"))
+        next_call = next(mock_calls)
+        assert next_call[0] == "client.put"
+        assert next_call[1] == ("foo/bar/baz3", os.path.join(source, "foo", "bar", "baz3"))
+
+        # sync again.  no more ops.
+        assert asyncio.run(syncer.incremental_copy()) == 0
+        assert client.delete.call_count == 0
+        assert client.mkdirs.call_count == 4
+        assert client.put.call_count == 6
+
+        # delete a dir and its files, and create new files
+        (Path(source) / "bar" / "foo1").touch()
+        (Path(source) / "bar" / "foo2").touch()
+        (Path(source) / "bar" / "foo3").touch()
+        shutil.rmtree(Path(source) / "baz")
+        (Path(source) / "bop").touch()
+
+        # deleting the parent directory should result in the dir and file deleted in the proper order
+        parent = AsyncMock()
+        parent.attach_mock(client, "client")
+        assert asyncio.run(syncer.incremental_copy()) == 5
+        # only need to delete the parent dir
+        assert client.delete.call_count == 1
+        assert client.mkdirs.call_count == 4
+        assert client.put.call_count == 10
+        mock_calls = iter(parent.mock_calls)
+        next_call = next(mock_calls)
+        assert next_call[0] == "client.delete"
+        assert next_call[1] == ("baz",)
+        next_call = next(mock_calls)
+        assert next_call[0] == "client.put"
+        assert next_call[1] == ("bar/foo1", os.path.join(source, "bar", "foo1"))
+        next_call = next(mock_calls)
+        assert next_call[0] == "client.put"
+        assert next_call[1] == ("bar/foo2", os.path.join(source, "bar", "foo2"))
+        next_call = next(mock_calls)
+        assert next_call[0] == "client.put"
+        assert next_call[1] == ("bar/foo3", os.path.join(source, "bar", "foo3"))
+        next_call = next(mock_calls)
+        assert next_call[0] == "client.put"
+        assert next_call[1] == ("bop", os.path.join(source, "bop"))
+
+        # sync again.  no more ops.
+        assert asyncio.run(syncer.incremental_copy()) == 0
+        assert client.delete.call_count == 1
+        assert client.mkdirs.call_count == 4
+        assert client.put.call_count == 10

--- a/tests/unit/sync/sync/test_many_files.py
+++ b/tests/unit/sync/sync/test_many_files.py
@@ -33,7 +33,7 @@ def test_syncing_many_files():
         )
 
         # initially no files
-        op_count = asyncio.run(syncer.incremental_copy())
+        op_count = syncer.incremental_copy()
         assert op_count == 0
         assert client.delete.call_count == 0
         assert client.mkdirs.call_count == 0
@@ -55,7 +55,7 @@ def test_syncing_many_files():
         parent.attach_mock(client, "client")
 
         # directory and file should be created in the proper order
-        assert asyncio.run(syncer.incremental_copy()) == 10
+        assert syncer.incremental_copy() == 10
         assert client.delete.call_count == 0
         assert client.mkdirs.call_count == 4
         assert client.put.call_count == 6
@@ -93,7 +93,7 @@ def test_syncing_many_files():
         assert next_call[1] == ("foo/bar/baz3", os.path.join(source, "foo", "bar", "baz3"))
 
         # sync again.  no more ops.
-        assert asyncio.run(syncer.incremental_copy()) == 0
+        assert syncer.incremental_copy() == 0
         assert client.delete.call_count == 0
         assert client.mkdirs.call_count == 4
         assert client.put.call_count == 6
@@ -108,7 +108,7 @@ def test_syncing_many_files():
         # deleting the parent directory should result in the dir and file deleted in the proper order
         parent = AsyncMock()
         parent.attach_mock(client, "client")
-        assert asyncio.run(syncer.incremental_copy()) == 5
+        assert syncer.incremental_copy() == 5
         # only need to delete the parent dir
         assert client.delete.call_count == 1
         assert client.mkdirs.call_count == 4
@@ -131,7 +131,7 @@ def test_syncing_many_files():
         assert next_call[1] == ("bop", os.path.join(source, "bop"))
 
         # sync again.  no more ops.
-        assert asyncio.run(syncer.incremental_copy()) == 0
+        assert syncer.incremental_copy() == 0
         assert client.delete.call_count == 1
         assert client.mkdirs.call_count == 4
         assert client.put.call_count == 10
@@ -159,7 +159,7 @@ def test_syncing_many_flat_dirs():
         )
 
         # initially no files
-        op_count = asyncio.run(syncer.incremental_copy())
+        op_count = syncer.incremental_copy()
         assert op_count == 0
         assert client.delete.call_count == 0
         assert client.mkdirs.call_count == 0
@@ -176,7 +176,7 @@ def test_syncing_many_flat_dirs():
         parent.attach_mock(client, "client")
 
         # directories should be created in the proper order
-        assert asyncio.run(syncer.incremental_copy()) == 5
+        assert syncer.incremental_copy() == 5
         assert client.delete.call_count == 0
         assert client.mkdirs.call_count == 5
         assert client.put.call_count == 0
@@ -209,7 +209,7 @@ def test_syncing_many_flat_dirs():
         parent.attach_mock(client, "client")
 
         # directories should be deleted in the proper order
-        assert asyncio.run(syncer.incremental_copy()) == 5
+        assert syncer.incremental_copy() == 5
         assert client.delete.call_count == 5
         assert client.mkdirs.call_count == 5
         assert client.put.call_count == 0
@@ -254,7 +254,7 @@ def test_syncing_many_nested_dirs():
         )
 
         # initially no files
-        op_count = asyncio.run(syncer.incremental_copy())
+        op_count = syncer.incremental_copy()
         assert op_count == 0
         assert client.delete.call_count == 0
         assert client.mkdirs.call_count == 0
@@ -269,7 +269,7 @@ def test_syncing_many_nested_dirs():
         parent.attach_mock(client, "client")
 
         # directories should be created in the proper order
-        assert asyncio.run(syncer.incremental_copy()) == 3
+        assert syncer.incremental_copy() == 3
         assert client.delete.call_count == 0
         assert client.mkdirs.call_count == 3
         assert client.put.call_count == 0
@@ -292,7 +292,7 @@ def test_syncing_many_nested_dirs():
         parent.attach_mock(client, "client")
 
         # directories should be deleted in the proper order
-        assert asyncio.run(syncer.incremental_copy()) == 1
+        assert syncer.incremental_copy() == 1
         assert client.delete.call_count == 1
         assert client.mkdirs.call_count == 3
         assert client.put.call_count == 0

--- a/tests/unit/sync/sync/test_sync.py
+++ b/tests/unit/sync/sync/test_sync.py
@@ -1,0 +1,231 @@
+import asyncio
+import os
+import shutil
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+from dbx.commands.sync import create_path_matcher
+from dbx.sync import RemoteSyncer
+
+from tests.unit.sync.utils import temporary_directory
+
+
+def test_empty_dir():
+    """
+    Tests that RemoteSyncer works with an empty directory.
+    """
+    client = MagicMock()
+    client.name = "test"
+    client.base_path = "/test"
+    with temporary_directory() as source, temporary_directory() as state_dir:
+        matcher = create_path_matcher(source=source, includes=None, excludes=None)
+        syncer = RemoteSyncer(
+            client=client,
+            source=source,
+            dry_run=False,
+            includes=None,
+            excludes=None,
+            full_sync=False,
+            state_dir=state_dir,
+            matcher=matcher,
+        )
+
+        # initially no files
+        assert asyncio.run(syncer.incremental_copy()) == 0
+        assert client.delete.call_count == 0
+        assert client.mkdirs.call_count == 0
+        assert client.put.call_count == 0
+
+        # stil no files
+        assert asyncio.run(syncer.incremental_copy()) == 0
+        assert client.delete.call_count == 0
+        assert client.mkdirs.call_count == 0
+        assert client.put.call_count == 0
+
+
+def test_single_file_put_and_delete():
+    """
+    Tests that RemoteSyncer can sync a file after it is created and then delete it after it is deleted.
+    """
+    client = AsyncMock()
+    client.name = "test"
+    client.base_path = "/test"
+    with temporary_directory() as source, temporary_directory() as state_dir:
+        matcher = create_path_matcher(source=source, includes=None, excludes=None)
+        syncer = RemoteSyncer(
+            client=client,
+            source=source,
+            dry_run=False,
+            includes=None,
+            excludes=None,
+            full_sync=False,
+            state_dir=state_dir,
+            matcher=matcher,
+        )
+
+        # initially no files
+        op_count = asyncio.run(syncer.incremental_copy())
+        assert op_count == 0
+        assert client.delete.call_count == 0
+        assert client.mkdirs.call_count == 0
+        assert client.put.call_count == 0
+
+        # create a file to sync
+        (Path(source) / "foo").touch()
+
+        # sync the file
+        assert asyncio.run(syncer.incremental_copy()) == 1
+        assert client.delete.call_count == 0
+        assert client.mkdirs.call_count == 0
+        assert client.put.call_count == 1
+
+        # should put the file remotely
+        assert client.put.call_args_list[0][0] == ("foo", os.path.join(source, "foo"))
+
+        # syncing again should result in no additional operations
+        assert asyncio.run(syncer.incremental_copy()) == 0
+        assert client.delete.call_count == 0
+        assert client.mkdirs.call_count == 0
+        assert client.put.call_count == 1
+
+        # remove the file locally, which should cause it to be removed remotely
+        os.remove(Path(source) / "foo")
+
+        assert asyncio.run(syncer.incremental_copy()) == 1
+        assert client.delete.call_count == 1
+        assert client.mkdirs.call_count == 0
+        assert client.put.call_count == 1
+
+        # should delete the remote file
+        assert client.delete.call_args_list[0][0] == ("foo",)
+
+        # syncing again should result in no additional operations
+        assert asyncio.run(syncer.incremental_copy()) == 0
+        assert client.delete.call_count == 1
+        assert client.mkdirs.call_count == 0
+        assert client.put.call_count == 1
+
+
+def test_put_dir_and_file_and_delete():
+    """
+    Tests that RemoteSyncer can sync a directory after it is created and then delete it after it is deleted.
+    """
+
+    client = AsyncMock()
+    client.name = "test"
+    client.base_path = "/test"
+    with temporary_directory() as source, temporary_directory() as state_dir:
+        matcher = create_path_matcher(source=source, includes=None, excludes=None)
+        syncer = RemoteSyncer(
+            client=client,
+            source=source,
+            dry_run=False,
+            includes=None,
+            excludes=None,
+            full_sync=False,
+            state_dir=state_dir,
+            matcher=matcher,
+        )
+
+        # initially no files
+        op_count = asyncio.run(syncer.incremental_copy())
+        assert op_count == 0
+        assert client.delete.call_count == 0
+        assert client.mkdirs.call_count == 0
+        assert client.put.call_count == 0
+
+        # create a directory and a file in that directory
+        (Path(source) / "foo").mkdir()
+        (Path(source) / "foo" / "bar").touch()
+
+        parent = AsyncMock()
+        parent.attach_mock(client, "client")
+
+        # directory and file should be created in the proper order
+        assert asyncio.run(syncer.incremental_copy()) == 2
+        assert client.delete.call_count == 0
+        assert client.mkdirs.call_count == 1
+        assert client.put.call_count == 1
+        assert parent.mock_calls[0][0] == "client.mkdirs"
+        assert parent.mock_calls[0][1] == ("foo",)
+        assert parent.mock_calls[1][0] == "client.put"
+        assert parent.mock_calls[1][1] == ("foo/bar", os.path.join(source, "foo", "bar"))
+
+        # sync again.  no more ops.
+        assert asyncio.run(syncer.incremental_copy()) == 0
+        assert client.delete.call_count == 0
+        assert client.mkdirs.call_count == 1
+        assert client.put.call_count == 1
+
+        # deleting the parent directory should result in the dir and file deleted by just the directory
+        # delete call.
+        parent = AsyncMock()
+        parent.attach_mock(client, "client")
+        shutil.rmtree(Path(source) / "foo")
+        assert asyncio.run(syncer.incremental_copy()) == 1
+        assert client.delete.call_count == 1
+        assert client.mkdirs.call_count == 1
+        assert client.put.call_count == 1
+        assert parent.mock_calls[0][0] == "client.delete"
+        assert parent.mock_calls[0][1] == ("foo",)
+
+        # sync again.  no more ops.
+        assert asyncio.run(syncer.incremental_copy()) == 0
+        assert client.delete.call_count == 1
+        assert client.mkdirs.call_count == 1
+        assert client.put.call_count == 1
+
+
+def test_single_file_put_twice():
+    """
+    Tests that RemoteSyncer can sync a file after it is created and then put it again after another update.
+    """
+    client = AsyncMock()
+    client.name = "test"
+    client.base_path = "/test"
+    with temporary_directory() as source, temporary_directory() as state_dir:
+        matcher = create_path_matcher(source=source, includes=None, excludes=None)
+        syncer = RemoteSyncer(
+            client=client,
+            source=source,
+            dry_run=False,
+            includes=None,
+            excludes=None,
+            full_sync=False,
+            state_dir=state_dir,
+            matcher=matcher,
+        )
+
+        # initially no files
+        op_count = asyncio.run(syncer.incremental_copy())
+        assert op_count == 0
+        assert client.delete.call_count == 0
+        assert client.mkdirs.call_count == 0
+        assert client.put.call_count == 0
+
+        # create a file to sync
+        (Path(source) / "foo").touch()
+
+        # sync the file
+        assert asyncio.run(syncer.incremental_copy()) == 1
+        assert client.delete.call_count == 0
+        assert client.mkdirs.call_count == 0
+        assert client.put.call_count == 1
+
+        # should put the file remotely
+        assert client.put.call_args_list[0][0] == ("foo", os.path.join(source, "foo"))
+
+        # syncing again should result in no additional operations
+        assert asyncio.run(syncer.incremental_copy()) == 0
+        assert client.delete.call_count == 0
+        assert client.mkdirs.call_count == 0
+        assert client.put.call_count == 1
+
+        # modify the file
+        with open(Path(source) / "foo", "w") as f:
+            f.write("blah")
+
+        assert asyncio.run(syncer.incremental_copy()) == 1
+        assert client.delete.call_count == 0
+        assert client.mkdirs.call_count == 0
+        assert client.put.call_count == 2

--- a/tests/unit/sync/sync/test_sync.py
+++ b/tests/unit/sync/sync/test_sync.py
@@ -33,13 +33,13 @@ def test_empty_dir():
         )
 
         # initially no files
-        assert asyncio.run(syncer.incremental_copy()) == 0
+        assert syncer.incremental_copy() == 0
         assert client.delete.call_count == 0
         assert client.mkdirs.call_count == 0
         assert client.put.call_count == 0
 
         # stil no files
-        assert asyncio.run(syncer.incremental_copy()) == 0
+        assert syncer.incremental_copy() == 0
         assert client.delete.call_count == 0
         assert client.mkdirs.call_count == 0
         assert client.put.call_count == 0
@@ -93,7 +93,7 @@ def test_single_file_put_and_delete():
         )
 
         # initially no files
-        op_count = asyncio.run(syncer.incremental_copy())
+        op_count = syncer.incremental_copy()
         assert op_count == 0
         assert client.delete.call_count == 0
         assert client.mkdirs.call_count == 0
@@ -103,7 +103,7 @@ def test_single_file_put_and_delete():
         (Path(source) / "foo").touch()
 
         # sync the file
-        assert asyncio.run(syncer.incremental_copy()) == 1
+        assert syncer.incremental_copy() == 1
         assert client.delete.call_count == 0
         assert client.mkdirs.call_count == 0
         assert client.put.call_count == 1
@@ -112,7 +112,7 @@ def test_single_file_put_and_delete():
         assert client.put.call_args_list[0][0] == ("foo", os.path.join(source, "foo"))
 
         # syncing again should result in no additional operations
-        assert asyncio.run(syncer.incremental_copy()) == 0
+        assert syncer.incremental_copy() == 0
         assert client.delete.call_count == 0
         assert client.mkdirs.call_count == 0
         assert client.put.call_count == 1
@@ -120,7 +120,7 @@ def test_single_file_put_and_delete():
         # remove the file locally, which should cause it to be removed remotely
         os.remove(Path(source) / "foo")
 
-        assert asyncio.run(syncer.incremental_copy()) == 1
+        assert syncer.incremental_copy() == 1
         assert client.delete.call_count == 1
         assert client.mkdirs.call_count == 0
         assert client.put.call_count == 1
@@ -129,7 +129,7 @@ def test_single_file_put_and_delete():
         assert client.delete.call_args_list[0][0] == ("foo",)
 
         # syncing again should result in no additional operations
-        assert asyncio.run(syncer.incremental_copy()) == 0
+        assert syncer.incremental_copy() == 0
         assert client.delete.call_count == 1
         assert client.mkdirs.call_count == 0
         assert client.put.call_count == 1
@@ -157,7 +157,7 @@ def test_put_dir_and_file_and_delete():
         )
 
         # initially no files
-        op_count = asyncio.run(syncer.incremental_copy())
+        op_count = syncer.incremental_copy()
         assert op_count == 0
         assert client.delete.call_count == 0
         assert client.mkdirs.call_count == 0
@@ -171,7 +171,7 @@ def test_put_dir_and_file_and_delete():
         parent.attach_mock(client, "client")
 
         # directory and file should be created in the proper order
-        assert asyncio.run(syncer.incremental_copy()) == 2
+        assert syncer.incremental_copy() == 2
         assert client.delete.call_count == 0
         assert client.mkdirs.call_count == 1
         assert client.put.call_count == 1
@@ -181,7 +181,7 @@ def test_put_dir_and_file_and_delete():
         assert parent.mock_calls[1][1] == ("foo/bar", os.path.join(source, "foo", "bar"))
 
         # sync again.  no more ops.
-        assert asyncio.run(syncer.incremental_copy()) == 0
+        assert syncer.incremental_copy() == 0
         assert client.delete.call_count == 0
         assert client.mkdirs.call_count == 1
         assert client.put.call_count == 1
@@ -191,7 +191,7 @@ def test_put_dir_and_file_and_delete():
         parent = AsyncMock()
         parent.attach_mock(client, "client")
         shutil.rmtree(Path(source) / "foo")
-        assert asyncio.run(syncer.incremental_copy()) == 1
+        assert syncer.incremental_copy() == 1
         assert client.delete.call_count == 1
         assert client.mkdirs.call_count == 1
         assert client.put.call_count == 1
@@ -199,7 +199,7 @@ def test_put_dir_and_file_and_delete():
         assert parent.mock_calls[0][1] == ("foo",)
 
         # sync again.  no more ops.
-        assert asyncio.run(syncer.incremental_copy()) == 0
+        assert syncer.incremental_copy() == 0
         assert client.delete.call_count == 1
         assert client.mkdirs.call_count == 1
         assert client.put.call_count == 1
@@ -226,7 +226,7 @@ def test_single_file_put_twice():
         )
 
         # initially no files
-        op_count = asyncio.run(syncer.incremental_copy())
+        op_count = syncer.incremental_copy()
         assert op_count == 0
         assert client.delete.call_count == 0
         assert client.mkdirs.call_count == 0
@@ -236,7 +236,7 @@ def test_single_file_put_twice():
         (Path(source) / "foo").touch()
 
         # sync the file
-        assert asyncio.run(syncer.incremental_copy()) == 1
+        assert syncer.incremental_copy() == 1
         assert client.delete.call_count == 0
         assert client.mkdirs.call_count == 0
         assert client.put.call_count == 1
@@ -245,7 +245,7 @@ def test_single_file_put_twice():
         assert client.put.call_args_list[0][0] == ("foo", os.path.join(source, "foo"))
 
         # syncing again should result in no additional operations
-        assert asyncio.run(syncer.incremental_copy()) == 0
+        assert syncer.incremental_copy() == 0
         assert client.delete.call_count == 0
         assert client.mkdirs.call_count == 0
         assert client.put.call_count == 1
@@ -254,7 +254,7 @@ def test_single_file_put_twice():
         with open(Path(source) / "foo", "w") as f:
             f.write("blah")
 
-        assert asyncio.run(syncer.incremental_copy()) == 1
+        assert syncer.incremental_copy() == 1
         assert client.delete.call_count == 0
         assert client.mkdirs.call_count == 0
         assert client.put.call_count == 2
@@ -300,7 +300,7 @@ def test_corrupt_state():
         syncer = _create_syncer()
 
         # initially no files
-        assert asyncio.run(syncer.incremental_copy()) == 0
+        assert syncer.incremental_copy() == 0
         assert client.delete.call_count == 0
         assert client.mkdirs.call_count == 0
         assert client.put.call_count == 0
@@ -309,13 +309,13 @@ def test_corrupt_state():
         (Path(source) / "foo").touch()
 
         # sync the file
-        assert asyncio.run(syncer.incremental_copy()) == 1
+        assert syncer.incremental_copy() == 1
         assert client.delete.call_count == 0
         assert client.mkdirs.call_count == 0
         assert client.put.call_count == 1
 
         # sync again, no ops because already synced
-        assert asyncio.run(syncer.incremental_copy()) == 0
+        assert syncer.incremental_copy() == 0
         assert client.delete.call_count == 0
         assert client.mkdirs.call_count == 0
         assert client.put.call_count == 1
@@ -324,7 +324,7 @@ def test_corrupt_state():
         syncer = _create_syncer()
 
         # sync again, no ops because already synced
-        assert asyncio.run(syncer.incremental_copy()) == 0
+        assert syncer.incremental_copy() == 0
         assert client.delete.call_count == 0
         assert client.mkdirs.call_count == 0
         assert client.put.call_count == 1
@@ -337,7 +337,7 @@ def test_corrupt_state():
         syncer = _create_syncer()
 
         # sync again, put happens again due to empty state
-        assert asyncio.run(syncer.incremental_copy()) == 1
+        assert syncer.incremental_copy() == 1
         assert client.delete.call_count == 0
         assert client.mkdirs.call_count == 0
         assert client.put.call_count == 2

--- a/tests/unit/sync/sync/test_unmatched_deletes.py
+++ b/tests/unit/sync/sync/test_unmatched_deletes.py
@@ -1,0 +1,104 @@
+import asyncio
+import os
+import shutil
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from dbx.commands.sync import create_path_matcher
+from dbx.sync import RemoteSyncer, DeleteUnmatchedOption
+
+from tests.unit.sync.utils import temporary_directory
+
+
+@pytest.mark.parametrize("confirm_delete,use_option", [(True, False), (False, False), (True, True), (False, True)])
+@patch("dbx.sync.click")
+def test_unmatched_delete_confirm_yes(mock_click, confirm_delete, use_option):
+    """
+    Tests that RemoteSyncer can properly handle unmatched deletes.
+
+    Unmatched deletes occur when the filter options (e.g. includes) change in such a way that files/directories
+    that were synced in a previous run are no longer matched.  Because the sync state keeps track of what has
+    been synced, this would result in the files being deleted in the destination.  This may or may not be what the
+    user wants to happen, so we give them the option to decide what to do.
+
+    If they don't specify an option, then we use click.confirm to ask whether they want to delete or not.
+    The alternative is to provide the option on the command line, which becomes the delete_unmatched_option param.
+    """
+    client = AsyncMock()
+    client.name = "test"
+    client.base_path = "/test"
+    with temporary_directory() as source, temporary_directory() as state_dir:
+
+        def create_syncer(*, includes=None, excludes=None):
+            matcher = create_path_matcher(source=source, includes=includes, excludes=excludes)
+            syncer_opts = dict(
+                client=client,
+                source=source,
+                dry_run=False,
+                includes=includes,
+                excludes=excludes,
+                full_sync=False,
+                state_dir=state_dir,
+                matcher=matcher,
+            )
+
+            if use_option:
+                delete_unmatched_option = (
+                    DeleteUnmatchedOption.ALLOW_DELETE_UNMATCHED
+                    if confirm_delete
+                    else DeleteUnmatchedOption.DISALLOW_DELETE_UNMATCHED
+                )
+                syncer_opts["delete_unmatched_option"] = delete_unmatched_option
+
+            return RemoteSyncer(**syncer_opts)
+
+        syncer = create_syncer(includes=["foo"])
+
+        # initially no files
+        op_count = asyncio.run(syncer.incremental_copy())
+        assert op_count == 0
+        assert client.delete.call_count == 0
+        assert client.mkdirs.call_count == 0
+        assert client.put.call_count == 0
+
+        # create two files, but only one will sync
+        (Path(source) / "foo").touch()
+        (Path(source) / "bar").touch()
+
+        # sync the file
+        assert asyncio.run(syncer.incremental_copy()) == 1
+        assert client.delete.call_count == 0
+        assert client.mkdirs.call_count == 0
+        assert client.put.call_count == 1
+
+        # should put the file remotely
+        assert client.put.call_args_list[0][0] == ("foo", os.path.join(source, "foo"))
+
+        # syncing again should result in no additional operations
+        assert asyncio.run(syncer.incremental_copy()) == 0
+        assert client.delete.call_count == 0
+        assert client.mkdirs.call_count == 0
+        assert client.put.call_count == 1
+
+        # recreate syncer with different includes, which would result in foo being deleted
+        syncer = create_syncer(includes=["bar"])
+
+        # confirm that we want to delete the files
+        mock_click.confirm.return_value = confirm_delete
+
+        if confirm_delete:
+            # syncing again should result in a delete and put
+            assert asyncio.run(syncer.incremental_copy()) == 2
+            assert client.delete.call_count == 1
+            assert client.mkdirs.call_count == 0
+            assert client.put.call_count == 2
+        else:
+            # syncing again should result in only a put, as we ignore the previous file
+            assert asyncio.run(syncer.incremental_copy()) == 1
+            assert client.delete.call_count == 0
+            assert client.mkdirs.call_count == 0
+            assert client.put.call_count == 2
+
+        mock_click.confirm.call_count == (1 if not use_option else 0)

--- a/tests/unit/sync/sync/test_unmatched_deletes.py
+++ b/tests/unit/sync/sync/test_unmatched_deletes.py
@@ -57,7 +57,7 @@ def test_unmatched_delete_confirm_yes(mock_click, confirm_delete, use_option):
         syncer = create_syncer(includes=["foo"])
 
         # initially no files
-        op_count = asyncio.run(syncer.incremental_copy())
+        op_count = syncer.incremental_copy()
         assert op_count == 0
         assert client.delete.call_count == 0
         assert client.mkdirs.call_count == 0
@@ -68,7 +68,7 @@ def test_unmatched_delete_confirm_yes(mock_click, confirm_delete, use_option):
         (Path(source) / "bar").touch()
 
         # sync the file
-        assert asyncio.run(syncer.incremental_copy()) == 1
+        assert syncer.incremental_copy() == 1
         assert client.delete.call_count == 0
         assert client.mkdirs.call_count == 0
         assert client.put.call_count == 1
@@ -77,7 +77,7 @@ def test_unmatched_delete_confirm_yes(mock_click, confirm_delete, use_option):
         assert client.put.call_args_list[0][0] == ("foo", os.path.join(source, "foo"))
 
         # syncing again should result in no additional operations
-        assert asyncio.run(syncer.incremental_copy()) == 0
+        assert syncer.incremental_copy() == 0
         assert client.delete.call_count == 0
         assert client.mkdirs.call_count == 0
         assert client.put.call_count == 1
@@ -90,13 +90,13 @@ def test_unmatched_delete_confirm_yes(mock_click, confirm_delete, use_option):
 
         if confirm_delete:
             # syncing again should result in a delete and put
-            assert asyncio.run(syncer.incremental_copy()) == 2
+            assert syncer.incremental_copy() == 2
             assert client.delete.call_count == 1
             assert client.mkdirs.call_count == 0
             assert client.put.call_count == 2
         else:
             # syncing again should result in only a put, as we ignore the previous file
-            assert asyncio.run(syncer.incremental_copy()) == 1
+            assert syncer.incremental_copy() == 1
             assert client.delete.call_count == 0
             assert client.mkdirs.call_count == 0
             assert client.put.call_count == 2

--- a/tests/unit/sync/test_commands.py
+++ b/tests/unit/sync/test_commands.py
@@ -4,7 +4,7 @@ from unittest.mock import patch, call, MagicMock
 import click
 import pytest
 
-from dbx.commands.sync import check, dbfs, repo, get_user_name, get_source_base_name
+from dbx.commands.sync import dbfs, repo, get_user_name, get_source_base_name
 from dbx.sync import DeleteUnmatchedOption
 from dbx.sync.clients import DBFSClient, ReposClient
 
@@ -28,20 +28,6 @@ def test_get_source_base_name():
     assert get_source_base_name("/foo/bar/") == "bar"
     with pytest.raises(click.UsageError):
         get_source_base_name("/")
-
-
-@patch("dbx.commands.sync.get_databricks_config")
-def test_check(mock_get_config):
-    invoke_cli_runner(check, [])
-    assert mock_get_config.call_count == 1
-    assert mock_get_config.call_args == call(None)
-
-
-@patch("dbx.commands.sync.get_databricks_config")
-def test_check_with_profile(mock_get_config):
-    invoke_cli_runner(check, ["--profile", "foo"])
-    assert mock_get_config.call_count == 1
-    assert mock_get_config.call_args == call("foo")
 
 
 @patch("dbx.commands.sync.get_databricks_config")

--- a/tests/unit/sync/test_commands.py
+++ b/tests/unit/sync/test_commands.py
@@ -1,0 +1,357 @@
+import os
+from tempfile import TemporaryDirectory
+from unittest.mock import patch, call, MagicMock
+
+from dbx.commands.sync import check, dbfs, repo
+from dbx.sync.clients import DBFSClient, ReposClient
+
+from tests.unit.utils import invoke_cli_runner
+
+from .utils import temporary_directory, pushd
+
+
+@patch("dbx.commands.sync.get_databricks_config")
+def test_check(mock_get_config):
+    invoke_cli_runner(check, [])
+    assert mock_get_config.call_count == 1
+    assert mock_get_config.call_args == call(None)
+
+
+@patch("dbx.commands.sync.get_databricks_config")
+def test_check_with_profile(mock_get_config):
+    invoke_cli_runner(check, ["--profile", "foo"])
+    assert mock_get_config.call_count == 1
+    assert mock_get_config.call_args == call("foo")
+
+
+@patch("dbx.commands.sync.get_databricks_config")
+@patch("dbx.commands.sync.main_loop")
+def test_repo_no_opts(mock_get_config, mock_main_loop):
+    # some options are required
+    res = invoke_cli_runner(repo, [], expected_error=True)
+    assert "Missing option" in res.output
+
+
+@patch("dbx.commands.sync.main_loop")
+@patch("dbx.commands.sync.get_databricks_config")
+def test_repo_basic_opts(mock_get_config, mock_main_loop):
+    with temporary_directory() as tempdir:
+        config = MagicMock()
+        mock_get_config.return_value = config
+        invoke_cli_runner(repo, ["-s", tempdir, "-d", "the-repo", "-u", "me"])
+
+        assert mock_main_loop.call_count == 1
+        assert mock_get_config.call_count == 1
+
+        assert mock_main_loop.call_args[1]["source"] == tempdir
+        assert not mock_main_loop.call_args[1]["full_sync"]
+        assert not mock_main_loop.call_args[1]["dry_run"]
+        assert mock_main_loop.call_args[1]["includes"] == []
+        assert mock_main_loop.call_args[1]["excludes"] == []
+        assert mock_main_loop.call_args[1]["watch"]
+
+        client = mock_main_loop.call_args[1]["client"]
+
+        assert isinstance(client, ReposClient)
+        assert client.base_path == "/Repos/me/the-repo"
+
+
+@patch("dbx.commands.sync.main_loop")
+@patch("dbx.commands.sync.get_databricks_config")
+def test_repo_dry_run(mock_get_config, mock_main_loop):
+    with temporary_directory() as tempdir:
+        config = MagicMock()
+        mock_get_config.return_value = config
+        invoke_cli_runner(repo, ["-s", tempdir, "-d", "the-repo", "-u", "me", "--dry-run"])
+
+        assert mock_main_loop.call_count == 1
+        assert mock_get_config.call_count == 1
+
+        assert mock_main_loop.call_args[1]["source"] == tempdir
+        assert not mock_main_loop.call_args[1]["full_sync"]
+        assert mock_main_loop.call_args[1]["dry_run"]
+        assert mock_main_loop.call_args[1]["includes"] == []
+        assert mock_main_loop.call_args[1]["excludes"] == []
+        assert not mock_main_loop.call_args[1]["watch"]
+
+        client = mock_main_loop.call_args[1]["client"]
+
+        assert isinstance(client, ReposClient)
+        assert client.base_path == "/Repos/me/the-repo"
+
+
+@patch("dbx.commands.sync.main_loop")
+@patch("dbx.commands.sync.get_databricks_config")
+def test_repo_include_dir(mock_get_config, mock_main_loop):
+    with temporary_directory() as tempdir:
+
+        os.mkdir(os.path.join(tempdir, "foo"))
+
+        config = MagicMock()
+        mock_get_config.return_value = config
+        invoke_cli_runner(repo, ["-s", tempdir, "-d", "the-repo", "-u", "me", "-i", "foo"])
+
+        assert mock_main_loop.call_count == 1
+        assert mock_get_config.call_count == 1
+
+        assert mock_main_loop.call_args[1]["source"] == tempdir
+        assert not mock_main_loop.call_args[1]["full_sync"]
+        assert not mock_main_loop.call_args[1]["dry_run"]
+        assert mock_main_loop.call_args[1]["includes"] == ["/foo/"]
+        assert mock_main_loop.call_args[1]["excludes"] == []
+        assert mock_main_loop.call_args[1]["watch"]
+
+        client = mock_main_loop.call_args[1]["client"]
+
+        assert isinstance(client, ReposClient)
+        assert client.base_path == "/Repos/me/the-repo"
+
+
+@patch("dbx.commands.sync.main_loop")
+@patch("dbx.commands.sync.get_databricks_config")
+def test_repo_exclude_dir(mock_get_config, mock_main_loop):
+    with temporary_directory() as tempdir:
+
+        os.mkdir(os.path.join(tempdir, "foo"))
+
+        config = MagicMock()
+        mock_get_config.return_value = config
+        invoke_cli_runner(repo, ["-s", tempdir, "-d", "the-repo", "-u", "me", "-e", "foo"])
+
+        assert mock_main_loop.call_count == 1
+        assert mock_get_config.call_count == 1
+
+        assert mock_main_loop.call_args[1]["source"] == tempdir
+        assert not mock_main_loop.call_args[1]["full_sync"]
+        assert not mock_main_loop.call_args[1]["dry_run"]
+        assert mock_main_loop.call_args[1]["includes"] == []
+        assert mock_main_loop.call_args[1]["excludes"] == ["/foo/"]
+        assert mock_main_loop.call_args[1]["watch"]
+
+        client = mock_main_loop.call_args[1]["client"]
+
+        assert isinstance(client, ReposClient)
+        assert client.base_path == "/Repos/me/the-repo"
+
+
+@patch("dbx.commands.sync.main_loop")
+@patch("dbx.commands.sync.get_databricks_config")
+def test_repo_include_dir_not_exists(mock_get_config, mock_main_loop):
+    with temporary_directory() as tempdir:
+
+        # we don't create the "foo" subdir, so it should produce an error
+
+        config = MagicMock()
+        mock_get_config.return_value = config
+        res = invoke_cli_runner(repo, ["-s", tempdir, "-d", "the-repo", "-u", "me", "-i", "foo"], expected_error=True)
+
+        assert mock_main_loop.call_count == 0
+        assert mock_get_config.call_count == 1
+
+        assert "does not exist" in res.output
+
+
+@patch("dbx.commands.sync.main_loop")
+@patch("dbx.commands.sync.get_databricks_config")
+def test_repo_inferred_source(mock_get_config, mock_main_loop):
+    with temporary_directory() as tempdir, pushd(tempdir):
+        os.mkdir(os.path.join(tempdir, ".git"))
+
+        config = MagicMock()
+        mock_get_config.return_value = config
+        invoke_cli_runner(repo, ["-d", "the-repo", "-u", "me"])
+
+        assert mock_main_loop.call_count == 1
+        assert mock_get_config.call_count == 1
+
+        assert mock_main_loop.call_args[1]["source"] == tempdir
+        assert not mock_main_loop.call_args[1]["full_sync"]
+        assert not mock_main_loop.call_args[1]["dry_run"]
+        assert mock_main_loop.call_args[1]["includes"] == []
+        assert mock_main_loop.call_args[1]["excludes"] == []
+        assert mock_main_loop.call_args[1]["watch"]
+
+        client = mock_main_loop.call_args[1]["client"]
+
+        assert isinstance(client, ReposClient)
+        assert client.base_path == "/Repos/me/the-repo"
+
+
+@patch("dbx.commands.sync.main_loop")
+@patch("dbx.commands.sync.get_databricks_config")
+def test_repo_inferred_source_no_git(mock_get_config, mock_main_loop):
+    with temporary_directory() as tempdir, pushd(tempdir):
+
+        # source can only be inferred when the cwd contains a .git subdir
+
+        config = MagicMock()
+        mock_get_config.return_value = config
+        res = invoke_cli_runner(repo, ["-d", "the-repo", "-u", "me"], expected_error=True)
+
+        assert mock_main_loop.call_count == 0
+        assert mock_get_config.call_count == 1
+
+        assert "Must specify source" in res.output
+
+
+@patch("dbx.commands.sync.getuser")
+@patch("dbx.commands.sync.main_loop")
+@patch("dbx.commands.sync.get_databricks_config")
+def test_dbfs_no_opts(mock_get_config, mock_main_loop, mock_getuser):
+    with temporary_directory() as tempdir, pushd(tempdir):
+
+        # infer source based on cwd having a .git directory
+        os.mkdir(os.path.join(tempdir, ".git"))
+
+        config = MagicMock()
+        mock_get_config.return_value = config
+        mock_getuser.return_value = "me"
+
+        # we can run with no options as long as the source and user can be automatically inferred
+        invoke_cli_runner(dbfs, [])
+
+        assert mock_main_loop.call_count == 1
+        assert mock_get_config.call_count == 1
+
+        assert mock_main_loop.call_args[1]["source"] == tempdir
+        assert not mock_main_loop.call_args[1]["full_sync"]
+        assert not mock_main_loop.call_args[1]["dry_run"]
+        assert mock_main_loop.call_args[1]["includes"] == []
+        assert mock_main_loop.call_args[1]["excludes"] == []
+        assert mock_main_loop.call_args[1]["watch"]
+
+        client = mock_main_loop.call_args[1]["client"]
+
+        assert isinstance(client, DBFSClient)
+        assert client.base_path == f"dbfs:/tmp/users/me/{os.path.basename(tempdir)}"
+
+
+@patch("dbx.commands.sync.getuser")
+@patch("dbx.commands.sync.main_loop")
+@patch("dbx.commands.sync.get_databricks_config")
+def test_dbfs_dry_run(mock_get_config, mock_main_loop, mock_getuser):
+    with temporary_directory() as tempdir, pushd(tempdir):
+
+        # infer source based on cwd having a .git directory
+        os.mkdir(os.path.join(tempdir, ".git"))
+
+        config = MagicMock()
+        mock_get_config.return_value = config
+        mock_getuser.return_value = "me"
+
+        # we can run with no options as long as the source and user can be automatically inferred
+        invoke_cli_runner(dbfs, ["--dry-run"])
+
+        assert mock_main_loop.call_count == 1
+        assert mock_get_config.call_count == 1
+
+        assert mock_main_loop.call_args[1]["source"] == tempdir
+        assert not mock_main_loop.call_args[1]["full_sync"]
+        assert mock_main_loop.call_args[1]["dry_run"]
+        assert mock_main_loop.call_args[1]["includes"] == []
+        assert mock_main_loop.call_args[1]["excludes"] == []
+        assert not mock_main_loop.call_args[1]["watch"]
+
+        client = mock_main_loop.call_args[1]["client"]
+
+        assert isinstance(client, DBFSClient)
+        assert client.base_path == f"dbfs:/tmp/users/me/{os.path.basename(tempdir)}"
+
+
+@patch("dbx.commands.sync.getuser")
+@patch("dbx.commands.sync.main_loop")
+@patch("dbx.commands.sync.get_databricks_config")
+def test_dbfs_source_dest(mock_get_config, mock_main_loop, mock_getuser):
+    with temporary_directory() as tempdir:
+
+        config = MagicMock()
+        mock_get_config.return_value = config
+        mock_getuser.return_value = "me"
+
+        # we can run with no options as long as the source and user can be automatically inferred
+        invoke_cli_runner(dbfs, ["-s", tempdir, "-d", "/foo/bar"])
+
+        assert mock_main_loop.call_count == 1
+        assert mock_get_config.call_count == 1
+
+        assert mock_main_loop.call_args[1]["source"] == tempdir
+        assert not mock_main_loop.call_args[1]["full_sync"]
+        assert not mock_main_loop.call_args[1]["dry_run"]
+        assert mock_main_loop.call_args[1]["includes"] == []
+        assert mock_main_loop.call_args[1]["excludes"] == []
+        assert mock_main_loop.call_args[1]["watch"]
+
+        client = mock_main_loop.call_args[1]["client"]
+
+        assert isinstance(client, DBFSClient)
+        assert client.base_path == f"dbfs:/foo/bar"
+
+
+@patch("dbx.commands.sync.getuser")
+@patch("dbx.commands.sync.main_loop")
+@patch("dbx.commands.sync.get_databricks_config")
+def test_dbfs_specify_user(mock_get_config, mock_main_loop, mock_getuser):
+    with temporary_directory() as tempdir, pushd(tempdir):
+
+        # infer source based on cwd having a .git directory
+        os.mkdir(os.path.join(tempdir, ".git"))
+
+        config = MagicMock()
+        mock_get_config.return_value = config
+
+        # we can run with no options as long as the source and user can be automatically inferred
+        invoke_cli_runner(dbfs, ["-u", "someone"])
+
+        assert mock_main_loop.call_count == 1
+        assert mock_get_config.call_count == 1
+        assert mock_getuser.call_count == 0
+
+        assert mock_main_loop.call_args[1]["source"] == tempdir
+        assert not mock_main_loop.call_args[1]["full_sync"]
+        assert not mock_main_loop.call_args[1]["dry_run"]
+        assert mock_main_loop.call_args[1]["includes"] == []
+        assert mock_main_loop.call_args[1]["excludes"] == []
+        assert mock_main_loop.call_args[1]["watch"]
+
+        client = mock_main_loop.call_args[1]["client"]
+
+        assert isinstance(client, DBFSClient)
+        assert client.base_path == f"dbfs:/tmp/users/someone/{os.path.basename(tempdir)}"
+
+
+@patch("dbx.commands.sync.getuser")
+@patch("dbx.commands.sync.main_loop")
+@patch("dbx.commands.sync.get_databricks_config")
+def test_dbfs_unknown_user(mock_get_config, mock_main_loop, mock_getuser):
+    with temporary_directory() as tempdir:
+
+        config = MagicMock()
+        mock_get_config.return_value = config
+        mock_getuser.return_value = None
+
+        # we can run with no options as long as the source and user can be automatically inferred
+        res = invoke_cli_runner(dbfs, [], expected_error=True)
+
+        assert mock_main_loop.call_count == 0
+        assert mock_get_config.call_count == 1
+
+        assert "Destination path can't be automatically determined because the user is not known" in res.output
+
+
+@patch("dbx.commands.sync.getuser")
+@patch("dbx.commands.sync.main_loop")
+@patch("dbx.commands.sync.get_databricks_config")
+def test_dbfs_no_root(mock_get_config, mock_main_loop, mock_getuser):
+    with temporary_directory() as tempdir:
+
+        config = MagicMock()
+        mock_get_config.return_value = config
+        mock_getuser.return_value = "me"
+
+        # we can run with no options as long as the source and user can be automatically inferred
+        res = invoke_cli_runner(dbfs, ["-d", "/"], expected_error=True)
+
+        assert mock_main_loop.call_count == 0
+        assert mock_get_config.call_count == 1
+
+        assert "Destination cannot be the root path" in res.output

--- a/tests/unit/sync/test_config.py
+++ b/tests/unit/sync/test_config.py
@@ -1,0 +1,78 @@
+from unittest.mock import MagicMock, call, patch
+
+import click
+import databricks_cli
+import pytest
+
+from dbx.sync.config import has_valid_token, get_databricks_config
+from tests.unit.sync.utils import mocked_props
+
+
+@patch("dbx.sync.config.get_auth_headers")
+@patch("dbx.sync.config.requests")
+def test_has_valid_token(mock_requests, mock_get_auth_headers):
+    fake_headers = {"foo": "bar"}
+    mock_get_auth_headers.return_value = fake_headers
+    resp = mocked_props(status_code=200)
+    mock_requests.get.return_value = resp
+    config = mocked_props(token="fake-token", host="http://somewhere.asdf/fake/")
+    assert has_valid_token(config)
+
+    assert mock_requests.get.call_args == call(
+        "http://somewhere.asdf/fake/api/2.0/dbfs/list", json={"path": "/"}, headers=fake_headers
+    )
+
+
+@patch("dbx.sync.config.get_auth_headers")
+@patch("dbx.sync.config.requests")
+def test_not_has_valid_token(mock_requests, mock_get_auth_headers):
+    fake_headers = {"foo": "bar"}
+    mock_get_auth_headers.return_value = fake_headers
+    resp = mocked_props(status_code=401)
+    mock_requests.get.return_value = resp
+    config = mocked_props(token="fake-token", host="http://somewhere.asdf/fake/")
+    assert not has_valid_token(config)
+
+
+@patch("dbx.sync.config.has_valid_token")
+@patch("dbx.sync.config.get_config")
+def test_get_databricks_config_default(mock_get_config, mock_has_valid_token):
+    config = MagicMock()
+    mock_get_config.return_value = config
+    mock_has_valid_token.return_value = True
+    assert get_databricks_config() == config
+    assert mock_get_config.call_count == 1
+    assert mock_has_valid_token.call_args == call(config)
+
+
+@patch("dbx.sync.config.has_valid_token")
+@patch("dbx.sync.config.get_config")
+def test_get_databricks_config_default_invalid_token(mock_get_config, mock_has_valid_token):
+    config = MagicMock()
+    mock_get_config.return_value = config
+    mock_has_valid_token.return_value = False
+    with pytest.raises(click.UsageError):
+        get_databricks_config()
+    assert mock_get_config.call_count == 1
+    assert mock_has_valid_token.call_args == call(config)
+
+
+@patch("dbx.sync.config.has_valid_token")
+@patch("dbx.sync.config.get_config")
+def test_get_databricks_config_default_no_config(mock_get_config, mock_has_valid_token):
+    mock_get_config.return_value = None
+    mock_has_valid_token.return_value = False
+    with pytest.raises(click.UsageError):
+        get_databricks_config()
+    assert mock_get_config.call_count == 1
+    assert mock_has_valid_token.call_count == 0
+
+
+@patch("dbx.sync.config.has_valid_token")
+@patch("dbx.sync.config.get_config")
+def test_get_databricks_config_default_config_error(mock_get_config, mock_has_valid_token):
+    mock_get_config.side_effect = databricks_cli.utils.InvalidConfigurationError()
+    with pytest.raises(click.UsageError):
+        get_databricks_config()
+    assert mock_get_config.call_count == 1
+    assert mock_has_valid_token.call_count == 0

--- a/tests/unit/sync/test_config.py
+++ b/tests/unit/sync/test_config.py
@@ -8,11 +8,11 @@ from dbx.sync.config import has_valid_token, get_databricks_config
 from tests.unit.sync.utils import mocked_props
 
 
-@patch("dbx.sync.config.get_auth_headers")
+@patch("dbx.sync.config.get_headers")
 @patch("dbx.sync.config.requests")
-def test_has_valid_token(mock_requests, mock_get_auth_headers):
+def test_has_valid_token(mock_requests, mock_get_headers):
     fake_headers = {"foo": "bar"}
-    mock_get_auth_headers.return_value = fake_headers
+    mock_get_headers.return_value = fake_headers
     resp = mocked_props(status_code=200)
     mock_requests.get.return_value = resp
     config = mocked_props(token="fake-token", host="http://somewhere.asdf/fake/")
@@ -23,11 +23,11 @@ def test_has_valid_token(mock_requests, mock_get_auth_headers):
     )
 
 
-@patch("dbx.sync.config.get_auth_headers")
+@patch("dbx.sync.config.get_headers")
 @patch("dbx.sync.config.requests")
-def test_not_has_valid_token(mock_requests, mock_get_auth_headers):
+def test_not_has_valid_token(mock_requests, mock_get_headers):
     fake_headers = {"foo": "bar"}
-    mock_get_auth_headers.return_value = fake_headers
+    mock_get_headers.return_value = fake_headers
     resp = mocked_props(status_code=401)
     mock_requests.get.return_value = resp
     config = mocked_props(token="fake-token", host="http://somewhere.asdf/fake/")

--- a/tests/unit/sync/test_config.py
+++ b/tests/unit/sync/test_config.py
@@ -76,3 +76,16 @@ def test_get_databricks_config_default_config_error(mock_get_config, mock_has_va
         get_databricks_config()
     assert mock_get_config.call_count == 1
     assert mock_has_valid_token.call_count == 0
+
+
+@patch("dbx.sync.config.has_valid_token")
+@patch("dbx.sync.config.ProfileConfigProvider")
+def test_get_databricks_config_default(mock_provider_class, mock_has_valid_token):
+    config = MagicMock()
+    instance = mock_provider_class.return_value
+    instance.get_config.return_value = config
+    mock_has_valid_token.return_value = True
+    assert get_databricks_config("foo") == config
+    assert mock_has_valid_token.call_args == call(config)
+    assert mock_provider_class.call_count == 1
+    assert mock_provider_class.call_args == call("foo")

--- a/tests/unit/sync/test_event_handler.py
+++ b/tests/unit/sync/test_event_handler.py
@@ -1,0 +1,184 @@
+import os
+import time
+from contextlib import contextmanager
+from pathlib import Path
+from typing import List
+
+from watchdog.events import DirCreatedEvent, FileCreatedEvent, FileDeletedEvent, FileModifiedEvent, FileMovedEvent
+
+from dbx.sync.event_handler import CollectingEventHandler, file_watcher
+from dbx.sync.path_matcher import PathMatcher
+
+from .utils import temporary_directory
+
+
+@contextmanager
+def temp_event_handler(*, ignores: List[str] = None, includes: List[str] = None):
+    with temporary_directory() as tempdir:
+        matcher = PathMatcher(tempdir, includes=includes, ignores=ignores)
+        with file_watcher(source=tempdir, matcher=matcher) as event_handler:
+            yield (event_handler, Path(tempdir))
+
+
+def get_events(event_handler: CollectingEventHandler, expected: int, *, timeout_seconds: int = 5):
+    start_time = time.monotonic()
+    all_events = []
+    while time.monotonic() < start_time + 5:
+        events = event_handler.get_events()
+        if events:
+            all_events.extend(events)
+            if len(all_events) >= expected:
+                return all_events
+        time.sleep(0.05)
+    assert False, "Failed to collect the expected number of events"
+
+
+def test_event_handler_create_file():
+    """
+    Tests file_watcher can detect file creation.
+    """
+    with temp_event_handler(includes=["foo"]) as (event_handler, tempdir):
+        (tempdir / "foo").touch()
+        events = get_events(event_handler, expected=1)
+        assert len(events) == 1
+        assert isinstance(events[0], FileCreatedEvent)
+        assert events[0].src_path == os.path.join(tempdir, "foo")
+
+
+def test_event_handler_create_file_ignored():
+    """
+    Tests file_watcher can ignore file creation events we want to ignore.
+    """
+    with temp_event_handler(includes=["foo"]) as (event_handler, tempdir):
+        (tempdir / "bar").touch()
+        (tempdir / "foo").touch()
+        events = get_events(event_handler, expected=1)
+        assert len(events) == 1
+        assert isinstance(events[0], FileCreatedEvent)
+        assert events[0].src_path == os.path.join(tempdir, "foo")
+
+
+def test_event_handler_create_dir():
+    """
+    Tests file_watcher can detect directory creation.
+    """
+    with temp_event_handler(includes=["foo"]) as (event_handler, tempdir):
+        (tempdir / "foo").mkdir()
+        events = get_events(event_handler, expected=1)
+        assert len(events) == 1
+        assert isinstance(events[0], DirCreatedEvent)
+        assert events[0].src_path == os.path.join(tempdir, "foo")
+
+
+def test_event_handler_create_dir_ignored():
+    """
+    Tests file_watcher can ignore directory creation events we want to ignore.
+    """
+    with temp_event_handler(includes=["foo"]) as (event_handler, tempdir):
+        (tempdir / "bar").mkdir()
+        (tempdir / "foo").mkdir()
+        events = get_events(event_handler, expected=1)
+        assert len(events) == 1
+        assert isinstance(events[0], DirCreatedEvent)
+        assert events[0].src_path == os.path.join(tempdir, "foo")
+
+
+def test_event_handler_delete_file():
+    """
+    Tests file_watcher can detect file deletion.
+    """
+    with temp_event_handler(includes=["foo"]) as (event_handler, tempdir):
+        (tempdir / "foo").touch()
+        os.remove(tempdir / "foo")
+        events = get_events(event_handler, expected=2)
+        assert len(events) == 2
+        assert isinstance(events[0], FileCreatedEvent)
+        assert events[0].src_path == os.path.join(tempdir, "foo")
+        assert isinstance(events[1], FileDeletedEvent)
+        assert events[1].src_path == os.path.join(tempdir, "foo")
+
+
+def test_event_handler_delete_file_ignored():
+    """
+    Tests file_watcher can ignore file deletion events we want to ignore.
+    """
+    with temp_event_handler(includes=["foo"]) as (event_handler, tempdir):
+        (tempdir / "bar").touch()
+        os.remove(tempdir / "bar")
+        (tempdir / "foo").touch()
+        events = get_events(event_handler, expected=1)
+        assert len(events) == 1
+        assert isinstance(events[0], FileCreatedEvent)
+        assert events[0].src_path == os.path.join(tempdir, "foo")
+
+
+def test_event_handler_modify_file():
+    """
+    Tests file_watcher can detect file modification.
+    """
+    with temp_event_handler(includes=["foo"]) as (event_handler, tempdir):
+        (tempdir / "foo").touch()
+        (tempdir / "foo").touch()
+        events = get_events(event_handler, expected=2)
+        assert len(events) == 2
+        assert isinstance(events[0], FileCreatedEvent)
+        assert events[0].src_path == os.path.join(tempdir, "foo")
+        assert isinstance(events[1], FileModifiedEvent)
+        assert events[1].src_path == os.path.join(tempdir, "foo")
+
+
+def test_event_handler_modify_file_ignored():
+    """
+    Tests file_watcher can ignore file modification events we want to ignore.
+    """
+    with temp_event_handler(includes=["foo"]) as (event_handler, tempdir):
+        (tempdir / "bar").touch()
+        (tempdir / "bar").touch()
+        (tempdir / "foo").touch()
+        (tempdir / "foo").touch()
+        events = get_events(event_handler, expected=2)
+        assert len(events) == 2
+        assert isinstance(events[0], FileCreatedEvent)
+        assert events[0].src_path == os.path.join(tempdir, "foo")
+        assert isinstance(events[1], FileModifiedEvent)
+        assert events[1].src_path == os.path.join(tempdir, "foo")
+
+
+def test_event_handler_move_file():
+    """
+    Tests file_watcher can detect file moves.
+    """
+    with temp_event_handler(includes=["foo*"]) as (event_handler, tempdir):
+        (tempdir / "foo").touch()
+        os.rename(tempdir / "foo", tempdir / "foo2")
+        events = get_events(event_handler, expected=2)
+        assert len(events) == 2
+        assert isinstance(events[0], FileCreatedEvent)
+        assert events[0].src_path == os.path.join(tempdir, "foo")
+        assert isinstance(events[1], FileMovedEvent)
+        assert events[1].src_path == os.path.join(tempdir, "foo")
+
+
+def test_event_handler_move_file_ignored():
+    """
+    Tests file_watcher can ignore file move events we want to ignore.
+    """
+    with temp_event_handler(includes=["foo*"]) as (event_handler, tempdir):
+        (tempdir / "bar").touch()
+        os.rename(tempdir / "bar", tempdir / "bar2")
+        (tempdir / "foo").touch()
+        events = get_events(event_handler, expected=1)
+        assert len(events) == 1
+        assert isinstance(events[0], FileCreatedEvent)
+        assert events[0].src_path == os.path.join(tempdir, "foo")
+
+
+def test_keyboard_interrupt():
+    """
+    Tests that the keyboard interrupt will cause the file watcher to stop without throwing an error.
+    """
+    with temporary_directory() as tempdir:
+        matcher = PathMatcher(tempdir, includes=None, ignores=None)
+        with file_watcher(source=tempdir, matcher=matcher):
+            # this should be captured by the file_watcher
+            raise KeyboardInterrupt()

--- a/tests/unit/sync/test_main_loop.py
+++ b/tests/unit/sync/test_main_loop.py
@@ -1,7 +1,7 @@
 import tempfile
 from unittest.mock import AsyncMock, MagicMock, patch
 
-from dbx.commands.sync import StopIncrementalCopy, main_loop
+from dbx.commands.sync import main_loop
 
 from .utils import temporary_directory
 
@@ -71,7 +71,7 @@ def test_main_loop_watch(remote_syncer_class_mock, mock_file_watcher):
         remote_syncer_class_mock.return_value = remote_sync_mock
 
         # incremental_copy should be called four times, with the last time breaking out of the loop.
-        remote_sync_mock.incremental_copy.side_effect = [1, 1, 1, StopIncrementalCopy]
+        remote_sync_mock.incremental_copy.side_effect = [1, 1, 1, -1]
 
         mock_file_watch_result = MagicMock()
         mock_event_handler = MagicMock()
@@ -116,7 +116,7 @@ def test_main_loop_watch_no_events(remote_syncer_class_mock, mock_file_watcher):
         remote_syncer_class_mock.return_value = remote_sync_mock
 
         # incremental_copy should be called three times, with the last time breaking out of the loop.
-        remote_sync_mock.incremental_copy.side_effect = [1, 1, StopIncrementalCopy]
+        remote_sync_mock.incremental_copy.side_effect = [1, 1, -1]
 
         mock_file_watch_result = MagicMock()
         mock_event_handler = MagicMock()

--- a/tests/unit/sync/test_main_loop.py
+++ b/tests/unit/sync/test_main_loop.py
@@ -1,5 +1,5 @@
 import tempfile
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import MagicMock, patch
 
 from dbx.commands.sync import main_loop
 
@@ -10,7 +10,7 @@ from .utils import temporary_directory
 def test_main_loop_no_watch(remote_syncer_class_mock):
     with temporary_directory() as source:
         client = MagicMock()
-        remote_sync_mock = AsyncMock()
+        remote_sync_mock = MagicMock()
         remote_syncer_class_mock.return_value = remote_sync_mock
         remote_sync_mock.incremental_copy.return_value = 0
         main_loop(
@@ -38,7 +38,7 @@ def test_main_loop_no_watch(remote_syncer_class_mock):
 def test_main_loop_dry_run(remote_syncer_class_mock):
     with temporary_directory() as source:
         client = MagicMock()
-        remote_sync_mock = AsyncMock()
+        remote_sync_mock = MagicMock()
         remote_syncer_class_mock.return_value = remote_sync_mock
         remote_sync_mock.incremental_copy.return_value = 5
         main_loop(
@@ -67,7 +67,7 @@ def test_main_loop_dry_run(remote_syncer_class_mock):
 def test_main_loop_watch(remote_syncer_class_mock, mock_file_watcher):
     with temporary_directory() as source:
         client = MagicMock()
-        remote_sync_mock = AsyncMock()
+        remote_sync_mock = MagicMock()
         remote_syncer_class_mock.return_value = remote_sync_mock
 
         # incremental_copy should be called four times, with the last time breaking out of the loop.
@@ -112,7 +112,7 @@ def test_main_loop_watch_no_events(remote_syncer_class_mock, mock_file_watcher):
 
     with temporary_directory() as source:
         client = MagicMock()
-        remote_sync_mock = AsyncMock()
+        remote_sync_mock = MagicMock()
         remote_syncer_class_mock.return_value = remote_sync_mock
 
         # incremental_copy should be called three times, with the last time breaking out of the loop.

--- a/tests/unit/sync/test_main_loop.py
+++ b/tests/unit/sync/test_main_loop.py
@@ -1,0 +1,156 @@
+import tempfile
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from dbx.commands.sync import StopIncrementalCopy, main_loop
+
+from .utils import temporary_directory
+
+
+@patch("dbx.commands.sync.RemoteSyncer")
+def test_main_loop_no_watch(remote_syncer_class_mock):
+    with temporary_directory() as source:
+        client = MagicMock()
+        remote_sync_mock = AsyncMock()
+        remote_syncer_class_mock.return_value = remote_sync_mock
+        remote_sync_mock.incremental_copy.return_value = 0
+        main_loop(
+            source=source,
+            client=client,
+            full_sync=False,
+            dry_run=False,
+            includes=None,
+            excludes=None,
+            watch=False,
+        )
+
+        assert remote_sync_mock.incremental_copy.call_count == 1
+
+        assert remote_syncer_class_mock.call_args[1]["source"] == source
+        assert remote_syncer_class_mock.call_args[1]["client"] == client
+        assert not remote_syncer_class_mock.call_args[1]["full_sync"]
+        assert not remote_syncer_class_mock.call_args[1]["dry_run"]
+        assert not remote_syncer_class_mock.call_args[1]["includes"]
+        assert not remote_syncer_class_mock.call_args[1]["excludes"]
+        assert remote_syncer_class_mock.call_args[1]["matcher"] is not None
+
+
+@patch("dbx.commands.sync.RemoteSyncer")
+def test_main_loop_dry_run(remote_syncer_class_mock):
+    with temporary_directory() as source:
+        client = MagicMock()
+        remote_sync_mock = AsyncMock()
+        remote_syncer_class_mock.return_value = remote_sync_mock
+        remote_sync_mock.incremental_copy.return_value = 5
+        main_loop(
+            source=source,
+            client=client,
+            full_sync=False,
+            dry_run=True,
+            includes=None,
+            excludes=None,
+            watch=False,
+        )
+
+        assert remote_sync_mock.incremental_copy.call_count == 1
+
+        assert remote_syncer_class_mock.call_args[1]["source"] == source
+        assert remote_syncer_class_mock.call_args[1]["client"] == client
+        assert not remote_syncer_class_mock.call_args[1]["full_sync"]
+        assert remote_syncer_class_mock.call_args[1]["dry_run"]
+        assert not remote_syncer_class_mock.call_args[1]["includes"]
+        assert not remote_syncer_class_mock.call_args[1]["excludes"]
+        assert remote_syncer_class_mock.call_args[1]["matcher"] is not None
+
+
+@patch("dbx.commands.sync.file_watcher")
+@patch("dbx.commands.sync.RemoteSyncer")
+def test_main_loop_watch(remote_syncer_class_mock, mock_file_watcher):
+    with temporary_directory() as source:
+        client = MagicMock()
+        remote_sync_mock = AsyncMock()
+        remote_syncer_class_mock.return_value = remote_sync_mock
+
+        # incremental_copy should be called four times, with the last time breaking out of the loop.
+        remote_sync_mock.incremental_copy.side_effect = [1, 1, 1, StopIncrementalCopy]
+
+        mock_file_watch_result = MagicMock()
+        mock_event_handler = MagicMock()
+        mock_file_watch_result.__enter__ = MagicMock(return_value=mock_event_handler)
+        mock_file_watch_result.__exit__ = MagicMock(return_value=False)
+        mock_event_handler.get_events.return_value = ["event1", "event2", "event3"]
+
+        mock_file_watcher.return_value = mock_file_watch_result
+
+        main_loop(
+            source=source,
+            client=client,
+            full_sync=False,
+            dry_run=False,
+            includes=None,
+            excludes=None,
+            watch=True,
+        )
+
+        assert remote_sync_mock.incremental_copy.call_count == 4
+        assert mock_event_handler.get_events.call_count == 3
+
+        assert remote_syncer_class_mock.call_args[1]["source"] == source
+        assert remote_syncer_class_mock.call_args[1]["client"] == client
+        assert not remote_syncer_class_mock.call_args[1]["full_sync"]
+        assert not remote_syncer_class_mock.call_args[1]["dry_run"]
+        assert not remote_syncer_class_mock.call_args[1]["includes"]
+        assert not remote_syncer_class_mock.call_args[1]["excludes"]
+        assert remote_syncer_class_mock.call_args[1]["matcher"] is not None
+
+
+@patch("dbx.commands.sync.file_watcher")
+@patch("dbx.commands.sync.RemoteSyncer")
+def test_main_loop_watch_no_events(remote_syncer_class_mock, mock_file_watcher):
+    """
+    Test running the main loop with one of the get_events calls returning no events, resulting in a short sleep.
+    """
+
+    with temporary_directory() as source:
+        client = MagicMock()
+        remote_sync_mock = AsyncMock()
+        remote_syncer_class_mock.return_value = remote_sync_mock
+
+        # incremental_copy should be called three times, with the last time breaking out of the loop.
+        remote_sync_mock.incremental_copy.side_effect = [1, 1, StopIncrementalCopy]
+
+        mock_file_watch_result = MagicMock()
+        mock_event_handler = MagicMock()
+        mock_file_watch_result.__enter__ = MagicMock(return_value=mock_event_handler)
+        mock_file_watch_result.__exit__ = MagicMock(return_value=False)
+        mock_event_handler.get_events.side_effect = [
+            # no events the first time, so incremental_copy isn't called
+            [],
+            # events for the second call, so incremental copy is called
+            ["event1"],
+            # events for the third call, so incremental copy is called
+            ["event2", "event3", "event4"],
+        ]
+
+        mock_file_watcher.return_value = mock_file_watch_result
+
+        main_loop(
+            source=source,
+            client=client,
+            full_sync=False,
+            dry_run=False,
+            includes=None,
+            excludes=None,
+            watch=True,
+            sleep_interval=0.05,
+        )
+
+        assert remote_sync_mock.incremental_copy.call_count == 3
+        assert mock_event_handler.get_events.call_count == 3
+
+        assert remote_syncer_class_mock.call_args[1]["source"] == source
+        assert remote_syncer_class_mock.call_args[1]["client"] == client
+        assert not remote_syncer_class_mock.call_args[1]["full_sync"]
+        assert not remote_syncer_class_mock.call_args[1]["dry_run"]
+        assert not remote_syncer_class_mock.call_args[1]["includes"]
+        assert not remote_syncer_class_mock.call_args[1]["excludes"]
+        assert remote_syncer_class_mock.call_args[1]["matcher"] is not None

--- a/tests/unit/sync/test_path_matcher.py
+++ b/tests/unit/sync/test_path_matcher.py
@@ -1,0 +1,298 @@
+import os
+from pathlib import Path
+
+import pytest
+
+from dbx.commands.sync import create_path_matcher
+from dbx.sync.path_matcher import PathMatcher
+
+from .utils import temporary_directory
+
+
+def test_no_rules():
+    """
+    Tests that with no rules, it matches everything.
+    """
+    with temporary_directory() as tempdir:
+        tempdir = Path(tempdir)
+
+        matcher = PathMatcher(tempdir)
+
+        (tempdir / "foo").mkdir()
+        (tempdir / "foo" / "bar").touch()
+        (tempdir / "baz").touch()
+
+        assert matcher.match(tempdir / "foo")
+        assert matcher.match(f"{tempdir}/foo")
+        assert matcher.match(tempdir / "foo" / "bar")
+        assert matcher.match(tempdir / "baz")
+
+        # only match files within the directory, not the directory itself
+        assert not matcher.match(tempdir)
+
+
+def test_invalid_root():
+    """
+    Tests that calling should_ignore on a path inconsistent with the root path is ignored.
+    """
+    with temporary_directory() as tempdir:
+        with temporary_directory() as tempdir2:
+            tempdir = Path(tempdir)
+            tempdir2 = Path(tempdir2)
+            matcher = PathMatcher(tempdir)
+
+            (tempdir / "foo").touch()
+            (tempdir2 / "foo").touch()
+
+            # sometimes events happen outside the target directory, which we ignore
+            assert not matcher.match(tempdir2 / "foo")
+
+
+def test_include_spec():
+    """
+    Tests that should_ignore can properly follow included patterns.
+    """
+    with temporary_directory() as tempdir:
+        tempdir = Path(tempdir)
+
+        matcher = PathMatcher(tempdir, includes=["foo/"])
+
+        (tempdir / "foo").mkdir()
+        (tempdir / "foo" / "bar").touch()
+        (tempdir / "bar").mkdir()
+        (tempdir / "baz").mkdir()
+        (tempdir / "bar" / "foo").touch()
+        (tempdir / "baz" / "foo").mkdir()
+        (tempdir / "baz" / "foo" / "wee").touch()
+        (tempdir / "bar" / "bop").touch()
+
+        # everything under the foo directory is included
+        assert matcher.match(tempdir / "foo")
+        assert matcher.match(tempdir / "foo" / "bar")
+
+        # a foo file in a subdirectory is not included
+        assert not matcher.match(tempdir / "bar" / "foo")
+
+        # but a foo directory in a subdirectory is, as well as anything under it
+        assert matcher.match(tempdir / "baz" / "foo")
+        assert matcher.match(tempdir / "baz" / "foo" / "wee")
+
+        assert not matcher.match(tempdir / "bar" / "bop")
+
+
+def test_ignore_spec():
+    """
+    Tests that should_ignore can properly follow ignored patterns.
+    """
+    with temporary_directory() as tempdir:
+        tempdir = Path(tempdir)
+
+        matcher = PathMatcher(tempdir, ignores=["foo/"])
+
+        (tempdir / "foo").mkdir()
+        (tempdir / "foo" / "bar").touch()
+        (tempdir / "bar").mkdir()
+        (tempdir / "baz").mkdir()
+        (tempdir / "bar" / "foo").touch()
+        (tempdir / "baz" / "foo").mkdir()
+        (tempdir / "baz" / "foo" / "wee").touch()
+        (tempdir / "bar" / "bop").touch()
+
+        # everything under the foo directory is included
+        assert not matcher.match(tempdir / "foo")
+        assert not matcher.match(tempdir / "foo" / "bar")
+
+        # a foo file in a subdirectory is not included
+        assert matcher.match(tempdir / "bar" / "foo")
+
+        # but a foo directory in a subdirectory is, as well as anything under it
+        assert not matcher.match(tempdir / "baz" / "foo")
+        assert not matcher.match(tempdir / "baz" / "foo" / "wee")
+
+        assert matcher.match(tempdir / "bar" / "bop")
+
+
+def test_ignore_and_include_spec():
+    """
+    Tests that should_ignore can properly follow included and ignored patterns when used together.
+    """
+    with temporary_directory() as tempdir:
+        tempdir = Path(tempdir)
+
+        matcher = PathMatcher(tempdir, includes=["foo/"], ignores=["foo/bar/"])
+
+        (tempdir / "foo").mkdir()
+        (tempdir / "foo" / "bar").mkdir()
+        (tempdir / "foo" / "baz").mkdir()
+        (tempdir / "foo" / "bar" / "bat").touch()
+
+        # everything under the foo directory is included except for bar/
+        assert matcher.match(tempdir / "foo")
+        assert not matcher.match(tempdir / "foo" / "bar")
+        assert not matcher.match(tempdir / "foo" / "bar" / "bat")
+        assert matcher.match(tempdir / "foo" / "baz")
+
+
+def test_create_path_matcher():
+    """
+    Tests using create_path_matcher to create the PathMatcher instead.
+    """
+    with temporary_directory() as tempdir:
+        tempdir = Path(tempdir)
+
+        (tempdir / "foo").mkdir()
+        (tempdir / "foo" / "bar").touch()
+
+        (tempdir / "baz").mkdir()
+        (tempdir / "baz" / "foo").touch()
+
+        matcher = create_path_matcher(source=tempdir, includes=None, excludes=None)
+
+        assert matcher.match(tempdir / "foo")
+        assert matcher.match(tempdir / "foo" / "bar")
+
+        assert matcher.match(tempdir / "baz")
+        assert matcher.match(tempdir / "baz" / "foo")
+
+
+def test_create_path_matcher_with_gitignore():
+    """
+    Tests using create_path_matcher to automatically handle .gitignore and .git.
+    """
+    with temporary_directory() as tempdir:
+        tempdir = Path(tempdir)
+
+        (tempdir / "foo").mkdir()
+        (tempdir / "foo" / "bar").touch()
+
+        # should be ignored
+        (tempdir / "baz").mkdir()
+        (tempdir / "baz" / "foo").touch()
+
+        # ignored by default
+        (tempdir / ".git").mkdir()
+        (tempdir / ".git" / "foo").touch()
+
+        # ignored by default
+        (tempdir / "blah.isorted").touch()
+
+        with open(os.path.join(tempdir, ".gitignore"), "w") as gitignore:
+            gitignore.write("bop/\n")
+
+        # should be ignored
+        (tempdir / "bop").mkdir()
+        (tempdir / "bop" / "foo").touch()
+
+        matcher = create_path_matcher(source=tempdir, excludes=["baz"], includes=None)
+
+        assert matcher.match(tempdir / "foo")
+        assert matcher.match(tempdir / "foo" / "bar")
+
+        assert not matcher.match(tempdir / "baz")
+        assert not matcher.match(tempdir / "baz" / "foo")
+
+        assert not matcher.match(tempdir / ".git")
+        assert not matcher.match(tempdir / ".git" / "foo")
+
+        assert not matcher.match(tempdir / "blah.isorted")
+
+        assert not matcher.match(tempdir / "bop")
+        assert not matcher.match(tempdir / "bop" / "foo")
+
+
+def test_create_path_matcher_with_syncinclude():
+    """
+    Tests using create_path_matcher to automatically handle .syncinclude.
+    """
+    with temporary_directory() as tempdir:
+        tempdir = Path(tempdir)
+
+        # should be ignored
+        (tempdir / "foo").mkdir()
+        (tempdir / "foo" / "bar").touch()
+
+        # should be ignored
+        (tempdir / "baz").mkdir()
+        (tempdir / "baz" / "foo").touch()
+
+        with open(os.path.join(tempdir, ".syncinclude"), "w") as syncinclude:
+            syncinclude.write("/bop/\n")
+
+        # should be included due to .syncinclude
+        (tempdir / "bop").mkdir()
+        (tempdir / "bop" / "foo").touch()
+
+        matcher = create_path_matcher(source=tempdir, excludes=None, includes=None)
+
+        assert not matcher.match(tempdir / "foo")
+        assert not matcher.match(tempdir / "foo" / "bar")
+
+        assert not matcher.match(tempdir / "baz")
+        assert not matcher.match(tempdir / "baz" / "foo")
+
+        assert matcher.match(tempdir / "bop")
+        assert matcher.match(tempdir / "bop" / "foo")
+
+
+def test_create_path_matcher_with_syncinclude_and_includes():
+    """
+    Tests using create_path_matcher to ignore .syncinclude when there are explicit includes.
+    """
+    with temporary_directory() as tempdir:
+        tempdir = Path(tempdir)
+
+        # included due to explicit include
+        (tempdir / "foo").mkdir()
+        (tempdir / "foo" / "bar").touch()
+
+        # should be ignored
+        (tempdir / "baz").mkdir()
+        (tempdir / "baz" / "foo").touch()
+
+        with open(os.path.join(tempdir, ".syncinclude"), "w") as syncinclude:
+            syncinclude.write("/bop/\n")
+
+        # despite being in .syncinclude, the includes overrides it
+        (tempdir / "bop").mkdir()
+        (tempdir / "bop" / "foo").touch()
+
+        matcher = create_path_matcher(source=tempdir, excludes=None, includes=["/foo/"])
+
+        assert matcher.match(tempdir / "foo")
+        assert matcher.match(tempdir / "foo" / "bar")
+
+        assert not matcher.match(tempdir / "baz")
+        assert not matcher.match(tempdir / "baz" / "foo")
+
+        assert not matcher.match(tempdir / "bop")
+        assert not matcher.match(tempdir / "bop" / "foo")
+
+
+def test_nonexistent_file():
+    """
+    Tests that the matcher can be applied to files that don't exist.
+    """
+    with temporary_directory() as tempdir:
+        tempdir = Path(tempdir)
+        matcher = PathMatcher(tempdir, includes=["foo/", "bar"])
+
+        # "foo/" will only match directories
+        assert not matcher.match(tempdir / "foo")
+        assert matcher.match(tempdir / "foo", is_directory=True)
+        assert not matcher.match(tempdir / "foo", is_directory=False)
+        assert not matcher.match(f"{tempdir}/foo")
+        assert matcher.match(f"{tempdir}/foo", is_directory=True)
+        assert not matcher.match(f"{tempdir}/foo", is_directory=False)
+        assert matcher.match(f"{tempdir}/foo/")
+
+        # "bar" matches either files or directories, so this will match all cases
+        assert matcher.match(tempdir / "bar")
+        assert matcher.match(tempdir / "bar", is_directory=True)
+        assert matcher.match(tempdir / "bar", is_directory=False)
+        assert matcher.match(f"{tempdir}/bar")
+        assert matcher.match(f"{tempdir}/bar", is_directory=True)
+        assert matcher.match(f"{tempdir}/bar", is_directory=False)
+        assert matcher.match(f"{tempdir}/bar/")
+
+        with pytest.raises(ValueError):
+            matcher.match(f"{tempdir}/bar/", is_directory=False)

--- a/tests/unit/sync/test_path_matcher.py
+++ b/tests/unit/sync/test_path_matcher.py
@@ -22,6 +22,9 @@ def test_no_rules():
         (tempdir / "foo" / "bar").touch()
         (tempdir / "baz").touch()
 
+        # never match the source itself
+        assert not matcher.match(tempdir)
+
         assert matcher.match(tempdir / "foo")
         assert matcher.match(f"{tempdir}/foo")
         assert matcher.match(tempdir / "foo" / "bar")
@@ -29,6 +32,7 @@ def test_no_rules():
 
         # only match files within the directory, not the directory itself
         assert not matcher.match(tempdir)
+        assert not matcher.match(f"{tempdir}/")
 
 
 def test_invalid_root():
@@ -66,6 +70,10 @@ def test_include_spec():
         (tempdir / "baz" / "foo" / "wee").touch()
         (tempdir / "bar" / "bop").touch()
 
+        # never match the source itself
+        assert not matcher.match(tempdir)
+        assert not matcher.match(f"{tempdir}/")
+
         # everything under the foo directory is included
         assert matcher.match(tempdir / "foo")
         assert matcher.match(tempdir / "foo" / "bar")
@@ -78,6 +86,8 @@ def test_include_spec():
         assert matcher.match(tempdir / "baz" / "foo" / "wee")
 
         assert not matcher.match(tempdir / "bar" / "bop")
+
+        assert not matcher.should_ignore(tempdir / "foo")
 
 
 def test_ignore_spec():
@@ -110,6 +120,8 @@ def test_ignore_spec():
         assert not matcher.match(tempdir / "baz" / "foo" / "wee")
 
         assert matcher.match(tempdir / "bar" / "bop")
+
+        assert matcher.should_ignore(tempdir / "foo")
 
 
 def test_ignore_and_include_spec():

--- a/tests/unit/sync/test_snapshot.py
+++ b/tests/unit/sync/test_snapshot.py
@@ -1,0 +1,301 @@
+import os
+import shutil
+from pathlib import Path
+
+from watchdog.utils.dirsnapshot import DirectorySnapshot
+
+from dbx.sync.snapshot import compute_snapshot_diff
+from dbx.sync import get_relative_path
+
+from .utils import temporary_directory
+
+
+def test_empty_dir():
+    with temporary_directory() as source:
+
+        # initially no files
+        snapshot1 = DirectorySnapshot(source)
+
+        # still no files
+        snapshot2 = DirectorySnapshot(source)
+
+        diff = compute_snapshot_diff(ref=snapshot1, snapshot=snapshot2)
+
+        assert len(diff.dirs_created) == 0
+        assert len(diff.dirs_deleted) == 0
+        assert len(diff.files_created) == 0
+        assert len(diff.files_deleted) == 0
+        assert len(diff.files_modified) == 0
+
+
+def test_create_dir():
+    with temporary_directory() as source:
+
+        snapshot1 = DirectorySnapshot(source)
+
+        (Path(source) / "foo").mkdir()
+
+        snapshot2 = DirectorySnapshot(source)
+
+        diff = compute_snapshot_diff(ref=snapshot1, snapshot=snapshot2)
+
+        assert len(diff.dirs_created) == 1
+        assert len(diff.dirs_deleted) == 0
+        assert len(diff.files_created) == 0
+        assert len(diff.files_deleted) == 0
+        assert len(diff.files_modified) == 0
+
+        assert get_relative_path(source, diff.dirs_created[0]) == "foo"
+
+
+def test_delete_dir():
+    with temporary_directory() as source:
+
+        (Path(source) / "foo").mkdir()
+
+        snapshot1 = DirectorySnapshot(source)
+
+        os.rmdir(Path(source) / "foo")
+
+        snapshot2 = DirectorySnapshot(source)
+
+        diff = compute_snapshot_diff(ref=snapshot1, snapshot=snapshot2)
+
+        assert len(diff.dirs_created) == 0
+        assert len(diff.dirs_deleted) == 1
+        assert len(diff.files_created) == 0
+        assert len(diff.files_deleted) == 0
+        assert len(diff.files_modified) == 0
+
+        assert get_relative_path(source, diff.dirs_deleted[0]) == "foo"
+
+
+def test_move_dir():
+    with temporary_directory() as source:
+
+        (Path(source) / "foo").mkdir()
+
+        snapshot1 = DirectorySnapshot(source)
+
+        os.rename((Path(source) / "foo"), (Path(source) / "foo2"))
+
+        snapshot2 = DirectorySnapshot(source)
+
+        diff = compute_snapshot_diff(ref=snapshot1, snapshot=snapshot2)
+
+        assert len(diff.dirs_created) == 1
+        assert len(diff.dirs_deleted) == 1
+        assert len(diff.files_created) == 0
+        assert len(diff.files_deleted) == 0
+        assert len(diff.files_modified) == 0
+
+        assert get_relative_path(source, diff.dirs_deleted[0]) == "foo"
+        assert get_relative_path(source, diff.dirs_created[0]) == "foo2"
+
+
+def test_create_file():
+    with temporary_directory() as source:
+
+        snapshot1 = DirectorySnapshot(source)
+
+        (Path(source) / "foo").touch()
+
+        snapshot2 = DirectorySnapshot(source)
+
+        diff = compute_snapshot_diff(ref=snapshot1, snapshot=snapshot2)
+
+        assert len(diff.dirs_created) == 0
+        assert len(diff.dirs_deleted) == 0
+        assert len(diff.files_created) == 1
+        assert len(diff.files_deleted) == 0
+        assert len(diff.files_modified) == 0
+
+        assert get_relative_path(source, diff.files_created[0]) == "foo"
+
+
+def test_delete_file():
+    with temporary_directory() as source:
+
+        (Path(source) / "foo").touch()
+
+        snapshot1 = DirectorySnapshot(source)
+
+        os.remove(Path(source) / "foo")
+
+        snapshot2 = DirectorySnapshot(source)
+
+        diff = compute_snapshot_diff(ref=snapshot1, snapshot=snapshot2)
+
+        assert len(diff.dirs_created) == 0
+        assert len(diff.dirs_deleted) == 0
+        assert len(diff.files_created) == 0
+        assert len(diff.files_deleted) == 1
+        assert len(diff.files_modified) == 0
+
+        assert get_relative_path(source, diff.files_deleted[0]) == "foo"
+
+
+def test_modify_file():
+    with temporary_directory() as source:
+
+        (Path(source) / "foo").touch()
+
+        snapshot1 = DirectorySnapshot(source)
+
+        with open(Path(source) / "foo", "w") as f:
+            f.write("blah")
+
+        snapshot2 = DirectorySnapshot(source)
+
+        diff = compute_snapshot_diff(ref=snapshot1, snapshot=snapshot2)
+
+        assert len(diff.dirs_created) == 0
+        assert len(diff.dirs_deleted) == 0
+        assert len(diff.files_created) == 0
+        assert len(diff.files_deleted) == 0
+        assert len(diff.files_modified) == 1
+
+        assert get_relative_path(source, diff.files_modified[0]) == "foo"
+
+
+def test_move_file():
+    with temporary_directory() as source:
+
+        (Path(source) / "foo").touch()
+
+        snapshot1 = DirectorySnapshot(source)
+
+        os.rename((Path(source) / "foo"), (Path(source) / "foo2"))
+
+        snapshot2 = DirectorySnapshot(source)
+
+        diff = compute_snapshot_diff(ref=snapshot1, snapshot=snapshot2)
+
+        assert len(diff.dirs_created) == 0
+        assert len(diff.dirs_deleted) == 0
+        assert len(diff.files_created) == 1
+        assert len(diff.files_deleted) == 1
+        assert len(diff.files_modified) == 0
+
+        assert get_relative_path(source, diff.files_deleted[0]) == "foo"
+        assert get_relative_path(source, diff.files_created[0]) == "foo2"
+
+
+def test_create_dir_with_file():
+    with temporary_directory() as source:
+
+        snapshot1 = DirectorySnapshot(source)
+
+        (Path(source) / "foo").mkdir()
+        (Path(source) / "foo" / "bar").touch()
+
+        snapshot2 = DirectorySnapshot(source)
+
+        diff = compute_snapshot_diff(ref=snapshot1, snapshot=snapshot2)
+
+        assert len(diff.dirs_created) == 1
+        assert len(diff.dirs_deleted) == 0
+        assert len(diff.files_created) == 1
+        assert len(diff.files_deleted) == 0
+        assert len(diff.files_modified) == 0
+
+        assert get_relative_path(source, diff.dirs_created[0]) == "foo"
+        assert Path(get_relative_path(source, diff.files_created[0])).as_posix() == "foo/bar"
+
+
+def test_move_dir_with_file():
+    with temporary_directory() as source:
+
+        (Path(source) / "foo").mkdir()
+        (Path(source) / "foo" / "bar").touch()
+
+        snapshot1 = DirectorySnapshot(source)
+
+        os.rename((Path(source) / "foo"), (Path(source) / "foo2"))
+
+        snapshot2 = DirectorySnapshot(source)
+
+        diff = compute_snapshot_diff(ref=snapshot1, snapshot=snapshot2)
+
+        assert len(diff.dirs_created) == 1
+        assert len(diff.dirs_deleted) == 1
+        assert len(diff.files_created) == 1
+        assert len(diff.files_deleted) == 1
+        assert len(diff.files_modified) == 0
+
+        assert get_relative_path(source, diff.dirs_deleted[0]) == "foo"
+        assert get_relative_path(source, diff.dirs_created[0]) == "foo2"
+        assert Path(get_relative_path(source, diff.files_deleted[0])).as_posix() == "foo/bar"
+        assert Path(get_relative_path(source, diff.files_created[0])).as_posix() == "foo2/bar"
+
+
+def test_delete_dir_with_file():
+    with temporary_directory() as source:
+
+        (Path(source) / "foo").mkdir()
+        (Path(source) / "foo" / "bar").touch()
+
+        snapshot1 = DirectorySnapshot(source)
+
+        shutil.rmtree(Path(source) / "foo")
+
+        snapshot2 = DirectorySnapshot(source)
+
+        diff = compute_snapshot_diff(ref=snapshot1, snapshot=snapshot2)
+
+        assert len(diff.dirs_created) == 0
+        assert len(diff.dirs_deleted) == 1
+        assert len(diff.files_created) == 0
+        assert len(diff.files_deleted) == 1
+        assert len(diff.files_modified) == 0
+
+        assert get_relative_path(source, diff.dirs_deleted[0]) == "foo"
+        assert Path(get_relative_path(source, diff.files_deleted[0])).as_posix() == "foo/bar"
+
+
+def test_replace_dir_with_file():
+    with temporary_directory() as source:
+
+        (Path(source) / "foo").mkdir()
+
+        snapshot1 = DirectorySnapshot(source)
+
+        os.rmdir(Path(source) / "foo")
+        (Path(source) / "foo").touch()
+
+        snapshot2 = DirectorySnapshot(source)
+
+        diff = compute_snapshot_diff(ref=snapshot1, snapshot=snapshot2)
+
+        assert len(diff.dirs_created) == 0
+        assert len(diff.dirs_deleted) == 1
+        assert len(diff.files_created) == 1
+        assert len(diff.files_deleted) == 0
+        assert len(diff.files_modified) == 0
+
+        assert get_relative_path(source, diff.dirs_deleted[0]) == "foo"
+        assert get_relative_path(source, diff.files_created[0]) == "foo"
+
+
+def test_replace_file_with_dir():
+    with temporary_directory() as source:
+
+        (Path(source) / "foo").touch()
+
+        snapshot1 = DirectorySnapshot(source)
+
+        os.remove(Path(source) / "foo")
+        (Path(source) / "foo").mkdir()
+
+        snapshot2 = DirectorySnapshot(source)
+
+        diff = compute_snapshot_diff(ref=snapshot1, snapshot=snapshot2)
+
+        assert len(diff.dirs_created) == 1
+        assert len(diff.dirs_deleted) == 0
+        assert len(diff.files_created) == 0
+        assert len(diff.files_deleted) == 1
+        assert len(diff.files_modified) == 0
+
+        assert get_relative_path(source, diff.dirs_created[0]) == "foo"
+        assert get_relative_path(source, diff.files_deleted[0]) == "foo"

--- a/tests/unit/sync/utils.py
+++ b/tests/unit/sync/utils.py
@@ -1,4 +1,5 @@
 import os
+import re
 from contextlib import contextmanager
 from tempfile import TemporaryDirectory
 
@@ -33,3 +34,11 @@ def pushd(d):
         yield
     finally:
         os.chdir(previous)
+
+
+def is_dbfs_user_agent(user_agent: str) -> bool:
+    return re.match(r"databricks-cli-[.\d]+-cicdtemplates-sync-dbfs", user_agent)
+
+
+def is_repos_user_agent(user_agent: str) -> bool:
+    return re.match(r"databricks-cli-[.\d]+-cicdtemplates-sync-repos", user_agent)

--- a/tests/unit/sync/utils.py
+++ b/tests/unit/sync/utils.py
@@ -1,0 +1,35 @@
+import os
+from contextlib import contextmanager
+from tempfile import TemporaryDirectory
+
+from unittest.mock import AsyncMock, MagicMock, PropertyMock
+
+
+def mocked_props(**props):
+    obj = MagicMock()
+    for k, v in props.items():
+        setattr(type(obj), k, PropertyMock(return_value=v))
+    return obj
+
+
+def create_async_with_result(result):
+    return_value = AsyncMock()
+    return_value.__aenter__.return_value = result
+    return_value.__aexit__.return_value = None
+    return return_value
+
+
+@contextmanager
+def temporary_directory():
+    with TemporaryDirectory() as tempdir:
+        yield os.path.realpath(tempdir)
+
+
+@contextmanager
+def pushd(d):
+    previous = os.getcwd()
+    os.chdir(d)
+    try:
+        yield
+    finally:
+        os.chdir(previous)


### PR DESCRIPTION
## Proposed changes

This adds a `sync` command with subcommands `dbfs` and `repos` (#232), which can incrementally sync local files to Databricks in order to enable quick, iterative development in a local IDE with the ability to test changes almost immediately in Databricks notebooks.  These commands by default watch for local file changes and rerun the incremental sync whenever changes are detected.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Further comments

Suppose you are using the [Repos for Git integration](https://docs.databricks.com/repos/index.html) feature and have cloned a git repo within Databricks where you have Python notebooks stored as well as various Python modules that the notebooks import.  You can edit any of these files directly in Databricks.  The `dbx sync repo` command provides an additional option: edit the files in a local repo on your computer in an IDE of your choice and sync the changes to the repo in Databricks as you make changes.

For example, when run from a local git clone, the following will sync all the files to an existing repo named `my-repo` in Databricks owned by `first.last@asdf.com` and watch for changes:

```
dbx sync repo -d my-repo -u first.last@asdf.com
```

(Note that `my-repo` above needs to be a repo created in Databricks, but that repo doesn't need to be a clone.  You can start with an empty repo.)

At the top of your notebook you can turn on autoreload so that execution of cells will automatically pick up the changes:

```
%load_ext autoreload
%autoreload 2
```

Many options are supported to control which files/directories to sync:

* `--source` / `-s` specifies the source, which defaults to the current directory if the current directory is a git repo.
* `--include` / `-i` can be used to specify one or more subdirectories under the source to include in the sync, where others are excluded.
* `--exclude` / `-e` can be used to specify one or more subdirectories under the source to exclude in the sync, where others are all included by default unless `-i` is used.
* `--include-pattern` / `-ip` can be used to specify one or more file patterns to include.  For example, `-ip "*.py"` causes all Python files in the repo to be synced, `ip lib/` causes all files under `lib` subdirectories to be synced, `-ip "lib/**/*.py"` causes only Python files under `lib` subdirectories to be synced, etc.  This uses the same syntax in a `.gitignore` file.
* `--exclude-pattern` / `-ep` can be used to specify one or more file patterns to exclude.

If there is a `.gitiginore` file the rules are automatically added as exclude patterns.  Likewise the `.git` subdirectory is automatically excluded.

The `dbx sync repo` command syncs to a repo in Databricks.  If that repo is a git clone you can see the changes made to the files, as if you'd made the edits directly in Databricks.  Alternatively, you can use `dbx sync dbfs` to sync the files to a path in DBFS.  This keeps the files independent from the repos but still allows you to use them in notebooks either in a repo or in notebooks existing in your workspace.

For example, when run from a local git clone in a `my-repo` directory under a user `first.last`, the following will sync all the files to the DBFS path `/tmp/users/first.last/my-repo`:

```
dbx sync dbfs
```

The destination path can also be specified, as in: `-d /tmp/my-repo`.  If the user can't be automatically detected you can specify it with `-u`.  In addition, all the other options supported by the `repo` command also work.

When executing notebooks in a repo, the root of the repo is automatically added to the Python path so that imports work relative to the repo root.  This means that aside from turning on autoreload you don't need to do anything else special for the changes to be reflected in the cell's execution.  However, when syncing to DBFS, for the imports to work you need to update the Python path to include this target directory you're syncing to.  For example, to import from the `/tmp/users/first.last/my-repo` path used above, use the following at the top of your notebook:

```
import sys

if "/tmp/users/first.last/my-repo" not in sys.path:
  sys.path.insert(0, "/tmp/users/first.last/my-repo")
```

A few other options/features supported by both `sync dbfs` and `sync repo` worth mentioning:

* `--dry-run` prints out what would be synced without making any changes.
* `--no-watch` only runs a single incremental sync and then quits, instead of watching for changes and incrementally syncing when they occur.
* `--full-sync` removes the local sync state and syncs all the files over again.  Usually when you quit and run the tool again it reloads the previous state so it doesn't need to copy all the files again.
* The default user to use with `repo` can be set with the environment variable `DBX_SYNC_REPO_USER`.

Compatibility notes:
* Mac: I've used these commands on a Mac and the unit tests pass on a Mac.
* Linux: Unit tests pass on Linux (verified by Github workflows).  I haven't tried using the commands on Linux.
* Windows: Unit tests pass on Windows and I've tested the commands on Windows.

Python version note:
* I bumped the version to 3.8 because 3.7 does not have `AsyncMock`, which is required by many of the tests to properly test the async code.

Docs:
* I have not added any documentation yet, but I can add documentation once this PR is further along in the review process.
