### PR TITLE
Fix for issue #241 - Format temporary dir paths as file:// URIs in pytest fixtures.

### DIFF
--- a/dbx/templates/projects/python_basic/render/{{cookiecutter.project_name}}/tests/unit/conftest.py
+++ b/dbx/templates/projects/python_basic/render/{{cookiecutter.project_name}}/tests/unit/conftest.py
@@ -81,7 +81,7 @@ def spark() -> SparkSession:
     warehouse_dir = tempfile.TemporaryDirectory().name
     _builder = (
         SparkSession.builder.master("local[1]")
-            .config("spark.hive.metastore.warehouse.dir", warehouse_dir)
+            .config("spark.hive.metastore.warehouse.dir", Path(warehouse_dir).as_uri())
             .config("spark.sql.extensions", "io.delta.sql.DeltaSparkSessionExtension")
             .config(
             "spark.sql.catalog.spark_catalog",
@@ -110,7 +110,7 @@ def mlflow_local():
     tracking_uri = tempfile.TemporaryDirectory().name
     registry_uri = f"sqlite:///{tempfile.TemporaryDirectory().name}"
 
-    mlflow.set_tracking_uri(tracking_uri)
+    mlflow.set_tracking_uri(Path(tracking_uri).as_uri())
     mlflow.set_registry_uri(registry_uri)
     logging.info("MLflow instance configured")
     yield None


### PR DESCRIPTION
Format temporary dir paths as file:// URIs to prevent mlflow.tracking.registry.UnsupportedModelRegistryStoreURIException error when running tests on Windows.

This will fix issue #241.


## Proposed changes

Windows uses weird file paths. Spark and MLflow don't understand schema of weird windows paths. This PR fixes weird windows paths for temporary directories created when setting up pytest fixtures in the example tests included with the "python_basic" dbx project template.

Before this PR: Example tests fails on Windows.

Before this PR: Example tests passes on Windows.


## Types of changes

What types of changes does your code introduce to dbx?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)


## Further comments

This is a very minor change.
