### PR TITLE
Remove scipy requirement

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,6 @@ INSTALL_REQUIRES = [
     "retry>=0.9.2",
     "requests>=2.24.0",
     "mlflow>=1.23.0",
-    "scipy<=1.7.3",  # 1.8.0 and higher require Python 3.8, we don't have such a limitation
     "tqdm>=4.50.0",
     "azure-identity>=1.7.1",
     "azure-mgmt-datafactory>=2.2.0",


### PR DESCRIPTION
Referring to https://github.com/databrickslabs/dbx/issues/227

As @scholer mentioned, dbx does not use scipy anywhere --> should not be specified in the requirements in `setup.py`.