### PR TITLE
[fix] config file not found

### DIFF
--- a/dbx/api/configure.py
+++ b/dbx/api/configure.py
@@ -14,7 +14,7 @@ class EnvironmentInfo:
     def __init__(self, profile: str, workspace_dir: Optional[str] = None, artifact_location: Optional[str] = None):
         self.profile = profile
         self.workspace_dir = f"/Shared/dbx/projects/{self._current_path_name}" if not workspace_dir else workspace_dir
-        self.artifact_location = f"dbfs:/dbx/{self._current_path_name}" if not artifact_location else artifact_location
+        self.artifact_location = f"/dbfs/dbx/{self._current_path_name}" if not artifact_location else artifact_location
 
     def as_dict(self) -> Dict[str, str]:
         return {

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ if sys.platform.startswith("win32"):
 
 setup(
     name="dbx",
-    python_requires=">=3.8",
+    python_requires=">=3.7",
     packages=find_packages(exclude=["tests", "tests.*"]),
     setup_requires=["wheel"],
     install_requires=INSTALL_REQUIRES,


### PR DESCRIPTION
## Proposed changes

When launching a new project structure using `dbx`, artifacts location path is created in the `project.json` file using non-Fuse pattern (dbfs:/). Due to this, config files are not found when running the jobs.

## Types of changes

What types of changes does your code introduce to dbx?
_Put an `x` in the boxes that apply_

- [X ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Further comments

Fixes #329
