### PR TITLE
Add additional include and exclude options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [X.Y.Z] - YYYY-MM-DD
 
+## Added
+
+- Additional `sync` command options (`--no-use-gitignore`, `--force-include`, etc.) for more control over what is synced.
+
 ----
 > Unreleased changes must be tracked above this line.
 > When releasing, Copy the changelog to below this line, with proper version and date.

--- a/dbx/commands/sync.py
+++ b/dbx/commands/sync.py
@@ -94,48 +94,73 @@ def sync():
     pass  # pragma: no cover
 
 
-def create_path_matcher(*, source: str, includes: List[str], excludes: List[str]) -> PathMatcher:
+def create_path_matcher(
+    *,
+    source: str,
+    include_dirs: List[str] = None,
+    exclude_dirs: List[str] = None,
+    include_patterns: List[str] = None,
+    exclude_patterns: List[str] = None,
+    force_include_dirs: List[str] = None,
+    force_include_patterns: List[str] = None,
+    use_gitignore: bool = True,
+) -> PathMatcher:
     """Set up a pattern matcher that is used to ignores changes to files we don't want synced.
 
     Args:
         source (str): root directory includes and excludes are relative to
-        includes (List[str]): Patterns to include.
-        excludes (List[str]): Patterns to exclude.
+        include_dirs (List[str]): Directories to include.
+        exclude_dirs (List[str]): Directories to exclude.
+        include_patterns (List[str]): Patterns to include.
+        exclude_patterns (List[str]): Patterns to exclude.
+        force_include_dirs (List[str]): Directories to include, even if they would otherwise be ignored due to
+                                        exclude dirs/patterns.
+        force_include_patterns (List[str]): Patterns to include, even if they would otherwise be ignored due to
+                                        exclude dirs/patterns.
+        use_gitignore (bool): Whether to use a .gitignore file, if it exists, to populate the list of exclude patterns,
+                              in addition to any other exclude patterns that may be provided.
 
     Returns:
         PathMatcher: matcher for matching files
     """
 
-    ignores = list(DEFAULT_IGNORES)
+    include_dirs = list(include_dirs) if include_dirs else []
+    exclude_dirs = list(exclude_dirs) if exclude_dirs else []
+    include_patterns = list(include_patterns) if include_patterns else []
+    exclude_patterns = list(exclude_patterns) if exclude_patterns else []
+    force_include_dirs = list(force_include_dirs) if force_include_dirs else []
+    force_include_patterns = list(force_include_patterns) if force_include_patterns else []
+
+    include_patterns.extend(subdirs_to_patterns(source, include_dirs))
+    exclude_patterns.extend(subdirs_to_patterns(source, exclude_dirs))
+    force_include_patterns.extend(subdirs_to_patterns(source, force_include_dirs))
 
     gitignore_path = os.path.join(source, ".gitignore")
-    if os.path.exists(gitignore_path):
+    if use_gitignore and os.path.exists(gitignore_path):
         dbx_echo(f"Ignoring patterns from {gitignore_path}")
         with open(gitignore_path, encoding="utf-8") as f:
-            ignores.extend(f.readlines())
+            exclude_patterns.extend([line.strip() for line in f.readlines()])
 
-    if not includes:
-        includes = []
-        syncinclude_path = os.path.join(source, ".syncinclude")
-        if os.path.exists(syncinclude_path):
-            dbx_echo(f"Including patterns from {syncinclude_path}")
-            with open(syncinclude_path, encoding="utf-8") as f:
-                includes.extend(f.readlines())
+    syncinclude_path = os.path.join(source, ".syncinclude")
+    if not include_patterns and os.path.exists(syncinclude_path):
+        dbx_echo(f"Including patterns from {syncinclude_path}")
+        with open(syncinclude_path, encoding="utf-8") as f:
+            include_patterns.extend([line.strip() for line in f.readlines()])
 
-    if excludes:
-        ignores.extend(excludes)
+    exclude_patterns.extend(DEFAULT_IGNORES)
 
-    return PathMatcher(root_dir=source, ignores=ignores, includes=includes)
+    return PathMatcher(
+        root_dir=source, ignores=exclude_patterns, includes=include_patterns, force_includes=force_include_patterns
+    )
 
 
 def main_loop(
     *,
     source: str,
+    matcher: PathMatcher,
     client: BaseClient,
     full_sync: bool,
     dry_run: bool,
-    includes: List[str],
-    excludes: List[str],
     watch: bool,
     sleep_interval: float = 0.25,
     polling_interval_secs: float = None,
@@ -146,13 +171,9 @@ def main_loop(
     an incremental sync whenever changes are detected.
     """
 
-    matcher = create_path_matcher(source=source, includes=includes, excludes=excludes)
-
     syncer = RemoteSyncer(
         client=client,
         source=source,
-        includes=includes,
-        excludes=excludes,
         dry_run=dry_run,
         full_sync=full_sync,
         matcher=matcher,
@@ -312,6 +333,27 @@ def common_options(f):
         """,
     )(f)
     f = click.option(
+        "--force-include",
+        "-fi",
+        "force_include_dirs",
+        multiple=True,
+        type=str,
+        required=False,
+        help="""A directory to sync, relative to the source directory.  This directory must exist.
+        When this option is used, no files or directories will be synced unless specifically included
+        by this or other include options.
+
+        Unlike `--include`, this will sync a directory regardless of files/directories that are excluded from
+        syncing.  This can be useful when, for example, the `.gitignore` lists a directory that you want to have
+        synced.  The patterns in the `.gitignore` are used by default to exclude files/directories from syncing.
+
+        For example:
+
+        * :code:`-i foo` will sync a directory `foo` directly under the source directory
+        * :code:`-i foo/bar` will sync a directory `foo/bar` directly under the source directory
+        """,
+    )(f)
+    f = click.option(
         "--exclude",
         "-e",
         "exclude_dirs",
@@ -348,6 +390,19 @@ def common_options(f):
         You may also store a list of patterns inside a :code:`.syncinclude` file under the source path.
         Patterns in this file will be used as the default patterns to include.  This essentially behaves
         as the opposite of a `gitignore <https://git-scm.com/docs/gitignore>`_ file, but with the same format.
+        """,
+    )(f)
+    f = click.option(
+        "--force-include-pattern",
+        "-fip",
+        "force_include_patterns",
+        multiple=True,
+        type=str,
+        required=False,
+        help="""A pattern specifying files and/or directories to sync, relative to the source directory, regardless
+        of whether these files and/or directories would otherwise be excluded.
+
+        See documentation of `--include-pattern` for usage.
         """,
     )(f)
     f = click.option(
@@ -400,6 +455,12 @@ def common_options(f):
         type=float,
         help="Use file system polling instead of file system events and set the polling interval (in seconds)",
     )(f)
+    f = click.option(
+        "--use-gitignore/--no-use-gitignore",
+        is_flag=True,
+        default=True,
+        help="""Controls whether the .gitignore is used to automatically exclude file/directories from syncing.""",
+    )(f)
     return f
 
 
@@ -440,13 +501,16 @@ def dbfs(
     full_sync: bool,
     dry_run: bool,
     include_dirs: List[str],
+    force_include_dirs: List[str],
     dest_path: str,
     exclude_dirs: List[str],
     profile: str,
     watch: bool,
     polling_interval_secs: float,
     include_patterns: List[str],
+    force_include_patterns: List[str],
     exclude_patterns: List[str],
+    use_gitignore: bool,
     delete_unmatched_option: DeleteUnmatchedOption,
 ):
     """
@@ -462,11 +526,16 @@ def dbfs(
 
     source = handle_source(source)
 
-    include_patterns = list(include_patterns) or []
-    exclude_patterns = list(exclude_patterns) or []
-
-    include_patterns.extend(subdirs_to_patterns(source, include_dirs))
-    exclude_patterns.extend(subdirs_to_patterns(source, exclude_dirs))
+    matcher = create_path_matcher(
+        source=source,
+        include_dirs=include_dirs,
+        exclude_dirs=exclude_dirs,
+        include_patterns=include_patterns,
+        exclude_patterns=exclude_patterns,
+        use_gitignore=use_gitignore,
+        force_include_dirs=force_include_dirs,
+        force_include_patterns=force_include_patterns,
+    )
 
     # To make the tool easier to use, pick a reasonable destination path under /tmp if one is not specified that is
     # highly unlikely to overwrite anything important.
@@ -495,11 +564,10 @@ def dbfs(
 
     main_loop(
         source=source,
+        matcher=matcher,
         client=client,
         full_sync=full_sync,
         dry_run=dry_run,
-        includes=include_patterns,
-        excludes=exclude_patterns,
         watch=watch,
         polling_interval_secs=polling_interval_secs,
         delete_unmatched_option=delete_unmatched_option,
@@ -539,13 +607,16 @@ def repo(
     full_sync: bool,
     dry_run: bool,
     include_dirs: List[str],
+    force_include_dirs: List[str],
     dest_repo: str,
     exclude_dirs: List[str],
     profile: str,
     watch: bool,
     polling_interval_secs: float,
     include_patterns: List[str],
+    force_include_patterns: List[str],
     exclude_patterns: List[str],
+    use_gitignore: bool,
     delete_unmatched_option: DeleteUnmatchedOption,
 ):
     """
@@ -570,21 +641,25 @@ def repo(
 
     source = handle_source(source)
 
-    include_patterns = list(include_patterns) or []
-    exclude_patterns = list(exclude_patterns) or []
-
-    include_patterns.extend(subdirs_to_patterns(source, include_dirs))
-    exclude_patterns.extend(subdirs_to_patterns(source, exclude_dirs))
+    matcher = create_path_matcher(
+        source=source,
+        include_dirs=include_dirs,
+        exclude_dirs=exclude_dirs,
+        include_patterns=include_patterns,
+        exclude_patterns=exclude_patterns,
+        use_gitignore=use_gitignore,
+        force_include_dirs=force_include_dirs,
+        force_include_patterns=force_include_patterns,
+    )
 
     client = ReposClient(user=user_name, repo_name=dest_repo, config=config)
 
     main_loop(
         source=source,
+        matcher=matcher,
         client=client,
         full_sync=full_sync,
         dry_run=dry_run,
-        includes=include_patterns,
-        excludes=exclude_patterns,
         watch=watch,
         polling_interval_secs=polling_interval_secs,
         delete_unmatched_option=delete_unmatched_option,

--- a/dbx/commands/sync.py
+++ b/dbx/commands/sync.py
@@ -135,13 +135,13 @@ def create_path_matcher(
     exclude_patterns.extend(subdirs_to_patterns(source, exclude_dirs))
     force_include_patterns.extend(subdirs_to_patterns(source, force_include_dirs))
 
-    gitignore_path = os.path.join(source, ".gitignore")
+    gitignore_path = Path(source) / ".gitignore"
     if use_gitignore and os.path.exists(gitignore_path):
         dbx_echo(f"Ignoring patterns from {gitignore_path}")
         with open(gitignore_path, encoding="utf-8") as f:
             exclude_patterns.extend([line.strip() for line in f.readlines()])
 
-    syncinclude_path = os.path.join(source, ".syncinclude")
+    syncinclude_path = Path(source) / ".syncinclude"
     if not include_patterns and os.path.exists(syncinclude_path):
         dbx_echo(f"Including patterns from {syncinclude_path}")
         with open(syncinclude_path, encoding="utf-8") as f:
@@ -234,7 +234,7 @@ def subdirs_to_patterns(source: str, subdirs: List[str]) -> List[str]:
     """
     patterns = []
     for subdir in subdirs:
-        full_subdir = os.path.join(source, subdir)
+        full_subdir = Path(source) / subdir
         if not os.path.exists(full_subdir):
             raise click.BadArgumentUsage(f"Path {full_subdir} does not exist")
         subdir = Path(subdir).as_posix()

--- a/dbx/commands/sync.py
+++ b/dbx/commands/sync.py
@@ -136,16 +136,14 @@ def create_path_matcher(
     force_include_patterns.extend(subdirs_to_patterns(source, force_include_dirs))
 
     gitignore_path = Path(source) / ".gitignore"
-    if use_gitignore and os.path.exists(gitignore_path):
+    if use_gitignore and gitignore_path.exists():
         dbx_echo(f"Ignoring patterns from {gitignore_path}")
-        with open(gitignore_path, encoding="utf-8") as f:
-            exclude_patterns.extend([line.strip() for line in f.readlines()])
+        exclude_patterns.extend(gitignore_path.read_text(encoding="utf-8").splitlines())
 
     syncinclude_path = Path(source) / ".syncinclude"
-    if not include_patterns and os.path.exists(syncinclude_path):
+    if not include_patterns and syncinclude_path.exists():
         dbx_echo(f"Including patterns from {syncinclude_path}")
-        with open(syncinclude_path, encoding="utf-8") as f:
-            include_patterns.extend([line.strip() for line in f.readlines()])
+        include_patterns.extend(syncinclude_path.read_text(encoding="utf-8").splitlines())
 
     exclude_patterns.extend(DEFAULT_IGNORES)
 
@@ -235,7 +233,7 @@ def subdirs_to_patterns(source: str, subdirs: List[str]) -> List[str]:
     patterns = []
     for subdir in subdirs:
         full_subdir = Path(source) / subdir
-        if not os.path.exists(full_subdir):
+        if not full_subdir.exists():
             raise click.BadArgumentUsage(f"Path {full_subdir} does not exist")
         subdir = Path(subdir).as_posix()
         patterns.append(f"/{subdir}/")

--- a/dbx/sync/__init__.py
+++ b/dbx/sync/__init__.py
@@ -110,7 +110,7 @@ class RemoteSyncer:
         self.is_first_sync = True
         self.tempdir = TemporaryDirectory().name  # noqa
         self.matcher = matcher
-        self.snapshot_path = os.path.join(state_dir, get_snapshot_name(client))
+        self.snapshot_path = Path(state_dir) / get_snapshot_name(client)
         self.last_snapshot = None
         self.delete_unmatched_option = delete_unmatched_option
 

--- a/dbx/sync/__init__.py
+++ b/dbx/sync/__init__.py
@@ -114,7 +114,7 @@ class RemoteSyncer:
         self.last_snapshot = None
         self.delete_unmatched_option = delete_unmatched_option
 
-        if not os.path.exists(state_dir):
+        if not state_dir.exists():
             os.makedirs(state_dir)
 
         if self.dry_run:
@@ -423,11 +423,11 @@ class RemoteSyncer:
 
         if self.is_first_sync:
             if self.full_sync:
-                if not self.dry_run and os.path.exists(self.snapshot_path):
+                if not self.dry_run and self.snapshot_path.exists():
                     os.remove(self.snapshot_path)
                 self.last_snapshot = EmptyDirectorySnapshot()
             else:
-                if os.path.exists(self.snapshot_path):
+                if self.snapshot_path.exists():
                     dbx_echo(f"Restoring sync snapshot from {self.snapshot_path}")
                     with open(self.snapshot_path, "rb") as f:
                         try:

--- a/dbx/sync/__init__.py
+++ b/dbx/sync/__init__.py
@@ -90,8 +90,6 @@ class RemoteSyncer:
         source: str,
         dry_run: bool,
         matcher: PathMatcher,
-        includes: List[str],
-        excludes: List[str],
         full_sync: bool = False,
         max_parallel: int = 4,
         max_parallel_puts: int = 10,
@@ -102,8 +100,6 @@ class RemoteSyncer:
         # be the same directory the tool is run from, but you can specify a different source directory.
         state_dir = Path(source) / Path(state_dir)
 
-        self.includes = includes
-        self.excludes = excludes
         self.client = client
         self.source = source
         self.state_dir = state_dir

--- a/dbx/sync/path_matcher.py
+++ b/dbx/sync/path_matcher.py
@@ -89,6 +89,10 @@ class PathMatcher:
 
         path = self._clean_relative_path(path, is_directory=is_directory)
 
+        # We certaintly will not ignore something that we've forced to be included.
+        if self.force_include_spec is not None and self.force_include_spec.match_file(path):
+            return False
+
         # If there is an ignore spec, then we'll ignore any paths that match.
         if self.ignore_spec is not None:
             return self.ignore_spec.match_file(path)
@@ -149,7 +153,7 @@ class PathMatcher:
 
 
 def filtered_listdir(matcher: PathMatcher, root: str):
-    """A wrapper around os.scandir that filters out paths that should be ignored according to rules in the
+    """A wrapper around os.scandir that filters out paths that should definitely be ignored according to rules in the
     given matcher.  Enabling this filtering makes the traversal more efficient.
 
     To, apply a partial to pass in the matcher:

--- a/dbx/sync/path_matcher.py
+++ b/dbx/sync/path_matcher.py
@@ -165,7 +165,7 @@ def filtered_listdir(matcher: PathMatcher, root: str):
         str: file/directory entries
     """
     for entry in os.scandir(root):
-        entry_name = os.path.join(root, entry if isinstance(entry, str) else entry.name)
+        entry_name = Path(root) / (entry if isinstance(entry, str) else entry.name)
         # Some paths are definitely ignored due to an ignore spec.  These should not be traversed.
         if not matcher.should_ignore(entry_name, is_directory=os.path.isdir(entry_name)):
             yield entry

--- a/tests/unit/sync/sync/test_dry_run.py
+++ b/tests/unit/sync/sync/test_dry_run.py
@@ -17,13 +17,11 @@ def test_single_file_put():
     client.name = "test"
     client.base_path = "/test"
     with temporary_directory() as source, temporary_directory() as state_dir:
-        matcher = create_path_matcher(source=source, includes=None, excludes=None)
+        matcher = create_path_matcher(source=source)
         syncer = RemoteSyncer(
             client=client,
             source=source,
             dry_run=True,
-            includes=None,
-            excludes=None,
             full_sync=False,
             state_dir=state_dir,
             matcher=matcher,
@@ -54,13 +52,11 @@ def test_mkdir_put():
     client.name = "test"
     client.base_path = "/test"
     with temporary_directory() as source, temporary_directory() as state_dir:
-        matcher = create_path_matcher(source=source, includes=None, excludes=None)
+        matcher = create_path_matcher(source=source)
         syncer = RemoteSyncer(
             client=client,
             source=source,
             dry_run=True,
-            includes=None,
-            excludes=None,
             full_sync=False,
             state_dir=state_dir,
             matcher=matcher,
@@ -92,15 +88,13 @@ def test_delete():
     client.name = "test"
     client.base_path = "/test"
     with temporary_directory() as source, temporary_directory() as state_dir:
-        matcher = create_path_matcher(source=source, includes=None, excludes=None)
+        matcher = create_path_matcher(source=source)
 
         # first syncer does not do dry run
         syncer = RemoteSyncer(
             client=client,
             source=source,
             dry_run=False,
-            includes=None,
-            excludes=None,
             full_sync=False,
             state_dir=state_dir,
             matcher=matcher,
@@ -131,8 +125,6 @@ def test_delete():
             client=client,
             source=source,
             dry_run=True,
-            includes=None,
-            excludes=None,
             full_sync=False,
             state_dir=state_dir,
             matcher=matcher,
@@ -156,13 +148,11 @@ def test_single_file_put_twice():
     client.name = "test"
     client.base_path = "/test"
     with temporary_directory() as source, temporary_directory() as state_dir:
-        matcher = create_path_matcher(source=source, includes=None, excludes=None)
+        matcher = create_path_matcher(source=source)
         syncer = RemoteSyncer(
             client=client,
             source=source,
             dry_run=True,
-            includes=None,
-            excludes=None,
             full_sync=False,
             state_dir=state_dir,
             matcher=matcher,

--- a/tests/unit/sync/sync/test_filtering.py
+++ b/tests/unit/sync/sync/test_filtering.py
@@ -21,19 +21,6 @@ def test_include():
     client.name = "test"
     client.base_path = "/test"
     with temporary_directory() as source, temporary_directory() as state_dir:
-        includes = ["foo"]
-        excludes = None
-        matcher = create_path_matcher(source=source, includes=includes, excludes=excludes)
-        syncer = RemoteSyncer(
-            client=client,
-            source=source,
-            dry_run=False,
-            includes=includes,
-            excludes=excludes,
-            full_sync=False,
-            state_dir=state_dir,
-            matcher=matcher,
-        )
 
         # create a dir and file to sync
         (Path(source) / "foo").mkdir()
@@ -43,6 +30,18 @@ def test_include():
         (Path(source) / "baz").touch()
         (Path(source) / "bar").mkdir()
         (Path(source) / "bar" / "baz").touch()
+
+        include_dirs = ["foo"]
+        exclude_dirs = None
+        matcher = create_path_matcher(source=source, include_dirs=include_dirs, exclude_dirs=exclude_dirs)
+        syncer = RemoteSyncer(
+            client=client,
+            source=source,
+            dry_run=False,
+            full_sync=False,
+            state_dir=state_dir,
+            matcher=matcher,
+        )
 
         parent = AsyncMock()
         parent.attach_mock(client, "client")
@@ -73,19 +72,6 @@ def test_default_ignore_git():
     client.name = "test"
     client.base_path = "/test"
     with temporary_directory() as source, temporary_directory() as state_dir:
-        includes = None
-        excludes = None
-        matcher = create_path_matcher(source=source, includes=includes, excludes=excludes)
-        syncer = RemoteSyncer(
-            client=client,
-            source=source,
-            dry_run=False,
-            includes=includes,
-            excludes=excludes,
-            full_sync=False,
-            state_dir=state_dir,
-            matcher=matcher,
-        )
 
         # create a dir and file to sync
         (Path(source) / "foo").mkdir()
@@ -94,6 +80,16 @@ def test_default_ignore_git():
         # and some dirs and files that should be ignored
         (Path(source) / ".git").mkdir()
         (Path(source) / ".git" / "foo").touch()
+
+        matcher = create_path_matcher(source=source)
+        syncer = RemoteSyncer(
+            client=client,
+            source=source,
+            dry_run=False,
+            full_sync=False,
+            state_dir=state_dir,
+            matcher=matcher,
+        )
 
         parent = AsyncMock()
         parent.attach_mock(client, "client")
@@ -124,19 +120,6 @@ def test_exclude():
     client.name = "test"
     client.base_path = "/test"
     with temporary_directory() as source, temporary_directory() as state_dir:
-        includes = None
-        excludes = ["baz"]
-        matcher = create_path_matcher(source=source, includes=includes, excludes=excludes)
-        syncer = RemoteSyncer(
-            client=client,
-            source=source,
-            dry_run=False,
-            includes=includes,
-            excludes=excludes,
-            full_sync=False,
-            state_dir=state_dir,
-            matcher=matcher,
-        )
 
         # create a dir and file to sync
         (Path(source) / "foo").mkdir()
@@ -145,6 +128,17 @@ def test_exclude():
         # and some dirs and files that should be ignored
         (Path(source) / "baz").mkdir()
         (Path(source) / "baz" / "bar").touch()
+
+        exclude_dirs = ["baz"]
+        matcher = create_path_matcher(source=source, exclude_dirs=exclude_dirs)
+        syncer = RemoteSyncer(
+            client=client,
+            source=source,
+            dry_run=False,
+            full_sync=False,
+            state_dir=state_dir,
+            matcher=matcher,
+        )
 
         parent = AsyncMock()
         parent.attach_mock(client, "client")
@@ -176,19 +170,6 @@ def test_include_deeply_nested():
     client.name = "test"
     client.base_path = "/test"
     with temporary_directory() as source, temporary_directory() as state_dir:
-        includes = ["foo/bar/baz"]
-        excludes = None
-        matcher = create_path_matcher(source=source, includes=includes, excludes=excludes)
-        syncer = RemoteSyncer(
-            client=client,
-            source=source,
-            dry_run=False,
-            includes=includes,
-            excludes=excludes,
-            full_sync=False,
-            state_dir=state_dir,
-            matcher=matcher,
-        )
 
         # create a dir and file to sync
         (Path(source) / "foo").mkdir()
@@ -200,6 +181,17 @@ def test_include_deeply_nested():
         (Path(source) / "baz").touch()
         (Path(source) / "bar").mkdir()
         (Path(source) / "bar" / "baz").touch()
+
+        include_dirs = ["foo/bar/baz"]
+        matcher = create_path_matcher(source=source, include_dirs=include_dirs)
+        syncer = RemoteSyncer(
+            client=client,
+            source=source,
+            dry_run=False,
+            full_sync=False,
+            state_dir=state_dir,
+            matcher=matcher,
+        )
 
         parent = AsyncMock()
         parent.attach_mock(client, "client")

--- a/tests/unit/sync/sync/test_full_sync.py
+++ b/tests/unit/sync/sync/test_full_sync.py
@@ -19,13 +19,11 @@ def test_initial_full_sync():
     client.name = "test"
     client.base_path = "/test"
     with temporary_directory() as source, temporary_directory() as state_dir:
-        matcher = create_path_matcher(source=source, includes=None, excludes=None)
+        matcher = create_path_matcher(source=source)
         syncer = RemoteSyncer(
             client=client,
             source=source,
             dry_run=False,
-            includes=None,
-            excludes=None,
             full_sync=True,
             state_dir=state_dir,
             matcher=matcher,
@@ -71,13 +69,11 @@ def test_full_sync_after_initial_sync():
     client.name = "test"
     client.base_path = "/test"
     with temporary_directory() as source, temporary_directory() as state_dir:
-        matcher = create_path_matcher(source=source, includes=None, excludes=None)
+        matcher = create_path_matcher(source=source)
         syncer = RemoteSyncer(
             client=client,
             source=source,
             dry_run=False,
-            includes=None,
-            excludes=None,
             full_sync=False,
             state_dir=state_dir,
             matcher=matcher,
@@ -118,8 +114,6 @@ def test_full_sync_after_initial_sync():
             client=client,
             source=source,
             dry_run=False,
-            includes=None,
-            excludes=None,
             full_sync=False,
             state_dir=state_dir,
             matcher=matcher,
@@ -136,8 +130,6 @@ def test_full_sync_after_initial_sync():
             client=client,
             source=source,
             dry_run=False,
-            includes=None,
-            excludes=None,
             full_sync=True,
             state_dir=state_dir,
             matcher=matcher,
@@ -165,13 +157,11 @@ def test_dry_run_full_sync_after_initial_sync():
     client.name = "test"
     client.base_path = "/test"
     with temporary_directory() as source, temporary_directory() as state_dir:
-        matcher = create_path_matcher(source=source, includes=None, excludes=None)
+        matcher = create_path_matcher(source=source)
         syncer = RemoteSyncer(
             client=client,
             source=source,
             dry_run=False,
-            includes=None,
-            excludes=None,
             full_sync=False,
             state_dir=state_dir,
             matcher=matcher,
@@ -212,8 +202,6 @@ def test_dry_run_full_sync_after_initial_sync():
             client=client,
             source=source,
             dry_run=True,
-            includes=None,
-            excludes=None,
             full_sync=True,
             state_dir=state_dir,
             matcher=matcher,

--- a/tests/unit/sync/sync/test_many_files.py
+++ b/tests/unit/sync/sync/test_many_files.py
@@ -20,13 +20,11 @@ def test_syncing_many_files():
     client.name = "test"
     client.base_path = "/test"
     with temporary_directory() as source, temporary_directory() as state_dir:
-        matcher = create_path_matcher(source=source, includes=None, excludes=None)
+        matcher = create_path_matcher(source=source)
         syncer = RemoteSyncer(
             client=client,
             source=source,
             dry_run=False,
-            includes=None,
-            excludes=None,
             full_sync=False,
             state_dir=state_dir,
             matcher=matcher,
@@ -146,13 +144,11 @@ def test_syncing_many_flat_dirs():
     client.name = "test"
     client.base_path = "/test"
     with temporary_directory() as source, temporary_directory() as state_dir:
-        matcher = create_path_matcher(source=source, includes=None, excludes=None)
+        matcher = create_path_matcher(source=source)
         syncer = RemoteSyncer(
             client=client,
             source=source,
             dry_run=False,
-            includes=None,
-            excludes=None,
             full_sync=False,
             state_dir=state_dir,
             matcher=matcher,
@@ -241,13 +237,11 @@ def test_syncing_many_nested_dirs():
     client.name = "test"
     client.base_path = "/test"
     with temporary_directory() as source, temporary_directory() as state_dir:
-        matcher = create_path_matcher(source=source, includes=None, excludes=None)
+        matcher = create_path_matcher(source=source)
         syncer = RemoteSyncer(
             client=client,
             source=source,
             dry_run=False,
-            includes=None,
-            excludes=None,
             full_sync=False,
             state_dir=state_dir,
             matcher=matcher,

--- a/tests/unit/sync/sync/test_sync.py
+++ b/tests/unit/sync/sync/test_sync.py
@@ -65,7 +65,7 @@ def test_state_dir_creation():
             matcher=matcher,
         )
 
-        assert os.path.exists(state_dir)
+        assert state_dir.exists()
 
 
 def test_single_file_put_and_delete():

--- a/tests/unit/sync/sync/test_sync.py
+++ b/tests/unit/sync/sync/test_sync.py
@@ -20,13 +20,11 @@ def test_empty_dir():
     client.name = "test"
     client.base_path = "/test"
     with temporary_directory() as source, temporary_directory() as state_dir:
-        matcher = create_path_matcher(source=source, includes=None, excludes=None)
+        matcher = create_path_matcher(source=source)
         syncer = RemoteSyncer(
             client=client,
             source=source,
             dry_run=False,
-            includes=None,
-            excludes=None,
             full_sync=False,
             state_dir=state_dir,
             matcher=matcher,
@@ -53,7 +51,7 @@ def test_state_dir_creation():
     client.name = "test"
     client.base_path = "/test"
     with temporary_directory() as source, temporary_directory() as state_dir:
-        matcher = create_path_matcher(source=source, includes=None, excludes=None)
+        matcher = create_path_matcher(source=source)
 
         # define a new state dir, but don't create it
         state_dir = Path(state_dir) / "state" / "really" / "nested"
@@ -62,8 +60,6 @@ def test_state_dir_creation():
             client=client,
             source=source,
             dry_run=False,
-            includes=None,
-            excludes=None,
             full_sync=False,
             state_dir=state_dir,
             matcher=matcher,
@@ -80,13 +76,11 @@ def test_single_file_put_and_delete():
     client.name = "test"
     client.base_path = "/test"
     with temporary_directory() as source, temporary_directory() as state_dir:
-        matcher = create_path_matcher(source=source, includes=None, excludes=None)
+        matcher = create_path_matcher(source=source)
         syncer = RemoteSyncer(
             client=client,
             source=source,
             dry_run=False,
-            includes=None,
-            excludes=None,
             full_sync=False,
             state_dir=state_dir,
             matcher=matcher,
@@ -144,13 +138,11 @@ def test_put_dir_and_file_and_delete():
     client.name = "test"
     client.base_path = "/test"
     with temporary_directory() as source, temporary_directory() as state_dir:
-        matcher = create_path_matcher(source=source, includes=None, excludes=None)
+        matcher = create_path_matcher(source=source)
         syncer = RemoteSyncer(
             client=client,
             source=source,
             dry_run=False,
-            includes=None,
-            excludes=None,
             full_sync=False,
             state_dir=state_dir,
             matcher=matcher,
@@ -213,13 +205,11 @@ def test_single_file_put_twice():
     client.name = "test"
     client.base_path = "/test"
     with temporary_directory() as source, temporary_directory() as state_dir:
-        matcher = create_path_matcher(source=source, includes=None, excludes=None)
+        matcher = create_path_matcher(source=source)
         syncer = RemoteSyncer(
             client=client,
             source=source,
             dry_run=False,
-            includes=None,
-            excludes=None,
             full_sync=False,
             state_dir=state_dir,
             matcher=matcher,
@@ -283,15 +273,13 @@ def test_corrupt_state():
     client.name = "test"
     client.base_path = "/test"
     with temporary_directory() as source, temporary_directory() as state_dir:
-        matcher = create_path_matcher(source=source, includes=None, excludes=None)
+        matcher = create_path_matcher(source=source)
 
         def _create_syncer():
             return RemoteSyncer(
                 client=client,
                 source=source,
                 dry_run=False,
-                includes=None,
-                excludes=None,
                 full_sync=False,
                 state_dir=state_dir,
                 matcher=matcher,

--- a/tests/unit/sync/sync/test_unmatched_deletes.py
+++ b/tests/unit/sync/sync/test_unmatched_deletes.py
@@ -32,8 +32,9 @@ def test_unmatched_delete_confirm_yes(mock_click, confirm_delete, use_option):
     with temporary_directory() as source, temporary_directory() as state_dir:
 
         def create_syncer(*, include_patterns=None, exclude_patterns=None):
-            matcher = create_path_matcher(source=source, include_patterns=include_patterns,
-                                          exclude_dirs=exclude_patterns)
+            matcher = create_path_matcher(
+                source=source, include_patterns=include_patterns, exclude_dirs=exclude_patterns
+            )
             syncer_opts = dict(
                 client=client,
                 source=source,

--- a/tests/unit/sync/sync/test_unmatched_deletes.py
+++ b/tests/unit/sync/sync/test_unmatched_deletes.py
@@ -31,14 +31,13 @@ def test_unmatched_delete_confirm_yes(mock_click, confirm_delete, use_option):
     client.base_path = "/test"
     with temporary_directory() as source, temporary_directory() as state_dir:
 
-        def create_syncer(*, includes=None, excludes=None):
-            matcher = create_path_matcher(source=source, includes=includes, excludes=excludes)
+        def create_syncer(*, include_patterns=None, exclude_patterns=None):
+            matcher = create_path_matcher(source=source, include_patterns=include_patterns,
+                                          exclude_dirs=exclude_patterns)
             syncer_opts = dict(
                 client=client,
                 source=source,
                 dry_run=False,
-                includes=includes,
-                excludes=excludes,
                 full_sync=False,
                 state_dir=state_dir,
                 matcher=matcher,
@@ -54,7 +53,7 @@ def test_unmatched_delete_confirm_yes(mock_click, confirm_delete, use_option):
 
             return RemoteSyncer(**syncer_opts)
 
-        syncer = create_syncer(includes=["foo"])
+        syncer = create_syncer(include_patterns=["foo"])
 
         # initially no files
         op_count = syncer.incremental_copy()
@@ -83,7 +82,7 @@ def test_unmatched_delete_confirm_yes(mock_click, confirm_delete, use_option):
         assert client.put.call_count == 1
 
         # recreate syncer with different includes, which would result in foo being deleted
-        syncer = create_syncer(includes=["bar"])
+        syncer = create_syncer(include_patterns=["bar"])
 
         # confirm that we want to delete the files
         mock_click.confirm.return_value = confirm_delete

--- a/tests/unit/sync/test_main_loop.py
+++ b/tests/unit/sync/test_main_loop.py
@@ -1,4 +1,3 @@
-import tempfile
 from unittest.mock import MagicMock, patch
 
 from dbx.commands.sync import main_loop
@@ -10,16 +9,16 @@ from .utils import temporary_directory
 def test_main_loop_no_watch(remote_syncer_class_mock):
     with temporary_directory() as source:
         client = MagicMock()
+        matcher = MagicMock()
         remote_sync_mock = MagicMock()
         remote_syncer_class_mock.return_value = remote_sync_mock
         remote_sync_mock.incremental_copy.return_value = 0
         main_loop(
             source=source,
+            matcher=matcher,
             client=client,
             full_sync=False,
             dry_run=False,
-            includes=None,
-            excludes=None,
             watch=False,
         )
 
@@ -29,25 +28,23 @@ def test_main_loop_no_watch(remote_syncer_class_mock):
         assert remote_syncer_class_mock.call_args[1]["client"] == client
         assert not remote_syncer_class_mock.call_args[1]["full_sync"]
         assert not remote_syncer_class_mock.call_args[1]["dry_run"]
-        assert not remote_syncer_class_mock.call_args[1]["includes"]
-        assert not remote_syncer_class_mock.call_args[1]["excludes"]
-        assert remote_syncer_class_mock.call_args[1]["matcher"] is not None
+        assert remote_syncer_class_mock.call_args[1]["matcher"] == matcher
 
 
 @patch("dbx.commands.sync.RemoteSyncer")
 def test_main_loop_dry_run(remote_syncer_class_mock):
     with temporary_directory() as source:
         client = MagicMock()
+        matcher = MagicMock()
         remote_sync_mock = MagicMock()
         remote_syncer_class_mock.return_value = remote_sync_mock
         remote_sync_mock.incremental_copy.return_value = 5
         main_loop(
             source=source,
+            matcher=matcher,
             client=client,
             full_sync=False,
             dry_run=True,
-            includes=None,
-            excludes=None,
             watch=False,
         )
 
@@ -57,9 +54,7 @@ def test_main_loop_dry_run(remote_syncer_class_mock):
         assert remote_syncer_class_mock.call_args[1]["client"] == client
         assert not remote_syncer_class_mock.call_args[1]["full_sync"]
         assert remote_syncer_class_mock.call_args[1]["dry_run"]
-        assert not remote_syncer_class_mock.call_args[1]["includes"]
-        assert not remote_syncer_class_mock.call_args[1]["excludes"]
-        assert remote_syncer_class_mock.call_args[1]["matcher"] is not None
+        assert remote_syncer_class_mock.call_args[1]["matcher"] == matcher
 
 
 @patch("dbx.commands.sync.file_watcher")
@@ -67,6 +62,7 @@ def test_main_loop_dry_run(remote_syncer_class_mock):
 def test_main_loop_watch(remote_syncer_class_mock, mock_file_watcher):
     with temporary_directory() as source:
         client = MagicMock()
+        matcher = MagicMock()
         remote_sync_mock = MagicMock()
         remote_syncer_class_mock.return_value = remote_sync_mock
 
@@ -83,11 +79,10 @@ def test_main_loop_watch(remote_syncer_class_mock, mock_file_watcher):
 
         main_loop(
             source=source,
+            matcher=matcher,
             client=client,
             full_sync=False,
             dry_run=False,
-            includes=None,
-            excludes=None,
             watch=True,
         )
 
@@ -98,9 +93,7 @@ def test_main_loop_watch(remote_syncer_class_mock, mock_file_watcher):
         assert remote_syncer_class_mock.call_args[1]["client"] == client
         assert not remote_syncer_class_mock.call_args[1]["full_sync"]
         assert not remote_syncer_class_mock.call_args[1]["dry_run"]
-        assert not remote_syncer_class_mock.call_args[1]["includes"]
-        assert not remote_syncer_class_mock.call_args[1]["excludes"]
-        assert remote_syncer_class_mock.call_args[1]["matcher"] is not None
+        assert remote_syncer_class_mock.call_args[1]["matcher"] == matcher
 
 
 @patch("dbx.commands.sync.file_watcher")
@@ -112,6 +105,7 @@ def test_main_loop_watch_no_events(remote_syncer_class_mock, mock_file_watcher):
 
     with temporary_directory() as source:
         client = MagicMock()
+        matcher = MagicMock()
         remote_sync_mock = MagicMock()
         remote_syncer_class_mock.return_value = remote_sync_mock
 
@@ -135,11 +129,10 @@ def test_main_loop_watch_no_events(remote_syncer_class_mock, mock_file_watcher):
 
         main_loop(
             source=source,
+            matcher=matcher,
             client=client,
             full_sync=False,
             dry_run=False,
-            includes=None,
-            excludes=None,
             watch=True,
             sleep_interval=0.05,
         )
@@ -151,6 +144,4 @@ def test_main_loop_watch_no_events(remote_syncer_class_mock, mock_file_watcher):
         assert remote_syncer_class_mock.call_args[1]["client"] == client
         assert not remote_syncer_class_mock.call_args[1]["full_sync"]
         assert not remote_syncer_class_mock.call_args[1]["dry_run"]
-        assert not remote_syncer_class_mock.call_args[1]["includes"]
-        assert not remote_syncer_class_mock.call_args[1]["excludes"]
-        assert remote_syncer_class_mock.call_args[1]["matcher"] is not None
+        assert remote_syncer_class_mock.call_args[1]["matcher"] == matcher


### PR DESCRIPTION
## Proposed changes

This addresses #323 by adding these additional options:

* `--use-gitignore/--no-use-gitignore` for controlling whether `.gitignore` is used to provide exclude patterns
* `--force-include` to force a directory to be included, even if it would otherwise be ignored by other rules (such as those provided by a `.gitignore` file)
* `--force-include-pattern` to force files/directories to be included according to the pattern, even if they would otherwise be ignored by other rules (such as those provided by a `.gitignore` file)

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Further comments

This does not change any existing behavior but merely provides additional options for controlling what to sync.
