### PR TITLE
Support for templates distributed in form of packages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Added
 
 - Additional `sync` command options (`--no-use-gitignore`, `--force-include`, etc.) for more control over what is synced.
-
+- Additional `init` command option `--template` was added to allow using dbx templates distributed as part of python packages.
 ----
 > Unreleased changes must be tracked above this line.
 > When releasing, Copy the changelog to below this line, with proper version and date.

--- a/dbx/commands/init.py
+++ b/dbx/commands/init.py
@@ -1,9 +1,11 @@
 from typing import List, Optional
 
 import click
+import pkg_resources
 from cookiecutter.main import cookiecutter
 from databricks_cli.configure.config import debug_option
 from databricks_cli.utils import CONTEXT_SETTINGS
+from pathlib import Path
 
 from dbx.utils import dbx_echo
 from dbx.constants import TEMPLATE_CHOICES, TEMPLATE_ROOT_PATH
@@ -34,6 +36,11 @@ DEFAULT_TEMPLATE = "python_basic"
     help="""External template used to kickoff the project. Cannot be used together with :code:`--template` option.""",
 )
 @click.option(
+    "--package",
+    required=False,
+    help="""Python package containing external template used to kickoff the project. Cannot be used together with :code:`--template` option.""",
+)
+@click.option(
     "--checkout",
     required=False,
     help="""Checkout argument for cookiecutter. Used only if :code:`--path` is used.""",
@@ -58,20 +65,21 @@ DEFAULT_TEMPLATE = "python_basic"
 def init(
     template: Optional[str],
     path: Optional[str],
+    package: Optional[str],
     checkout: Optional[str],
     parameters: Optional[List[str]],
     no_input: bool = False,
 ):
-    if template and path:
+    if sum([bool(template), bool(package), bool(path)]) > 1:
         raise Exception(
-            "Both --template and --path options are not supported."
-            "Please choose either built-in template or an external path"
+            "Only one option among  --template, --path and --package is supported."
+            "Please choose either built-in template or python package containing dbx template or external path to cookiecutter template!"
         )
-    if not path and template is None:
+    if not path and not package and template is None:
         template = DEFAULT_TEMPLATE
 
     msg_base = "Configuring new project from "
-    msg = f"template {template} :gear:" if template else f"path {path} :link:"
+    msg = f"template {template} :gear:" if template else f"path {path} :link:" if path else f"package {package} :link:"
 
     dbx_echo(msg_base + msg)
 
@@ -85,6 +93,12 @@ def init(
         splits = [item.split("=") for item in parameters]
         parameters = {item[0]: item[1] for item in splits}
 
-    _path = path if path else str(TEMPLATE_ROOT_PATH / template / "render")
+    if path:
+        _path = path
+    elif package:
+        _path = str(Path(pkg_resources.resource_filename(package, "render")))
+    else:
+        _path = str(TEMPLATE_ROOT_PATH / template / "render")
+
     cookiecutter(_path, extra_context=parameters, no_input=no_input, checkout=checkout)
     dbx_echo("Project configuration finished. You're all set to use dbx :fire:")

--- a/dbx/commands/init.py
+++ b/dbx/commands/init.py
@@ -1,11 +1,11 @@
 from typing import List, Optional
+from pathlib import Path
 
 import click
 import pkg_resources
 from cookiecutter.main import cookiecutter
 from databricks_cli.configure.config import debug_option
 from databricks_cli.utils import CONTEXT_SETTINGS
-from pathlib import Path
 
 from dbx.utils import dbx_echo
 from dbx.constants import TEMPLATE_CHOICES, TEMPLATE_ROOT_PATH
@@ -38,7 +38,8 @@ DEFAULT_TEMPLATE = "python_basic"
 @click.option(
     "--package",
     required=False,
-    help="""Python package containing external template used to kickoff the project. Cannot be used together with :code:`--template` option.""",
+    help="""Python package containing external template used to kickoff the project.
+    Cannot be used together with :code:`--template` option.""",
 )
 @click.option(
     "--checkout",
@@ -73,7 +74,8 @@ def init(
     if sum([bool(template), bool(package), bool(path)]) > 1:
         raise Exception(
             "Only one option among  --template, --path and --package is supported."
-            "Please choose either built-in template or python package containing dbx template or external path to cookiecutter template!"
+            "Please choose either built-in template or python package containing dbx template "
+            "or external path to cookiecutter template!"
         )
     if not path and not package and template is None:
         template = DEFAULT_TEMPLATE


### PR DESCRIPTION
## Proposed changes

This PR adds support for templates distributed in the form of python packages (e.g., wheels).
dbx init accepts now another parameter --package, which allows users to specify the python package with the template they want to use. 

## Types of changes

What types of changes does your code introduce to dbx?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
