### PR TITLE
Pass jobs_api_version to ApiClient constructor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 [Please read through the Keep a Changelog (~5min)](https://keepachangelog.com/en/1.0.0/).
 
+## [X.Y.Z] - YYYY-MM-DD
+
+## Fixed
+- Support `jobs_api_version` values provided by config in `ApiClient` construction
 
 ----
 > Unreleased changes must be tracked above this line.

--- a/dbx/api/client_provider.py
+++ b/dbx/api/client_provider.py
@@ -51,6 +51,7 @@ class DatabricksClientProvider:
         _client = ApiClient(
             host=config.host,
             token=config.token,
+            jobs_api_version=config.jobs_api_version
             verify=verify,
             command_name="cicdtemplates-",
         )

--- a/dbx/api/client_provider.py
+++ b/dbx/api/client_provider.py
@@ -51,7 +51,7 @@ class DatabricksClientProvider:
         _client = ApiClient(
             host=config.host,
             token=config.token,
-            jobs_api_version=config.jobs_api_version
+            jobs_api_version=config.jobs_api_version,
             verify=verify,
             command_name="cicdtemplates-",
         )


### PR DESCRIPTION
Pass the jobs_api_version to the ApiClient so that jobs API endpoint urls use the appropriate Jobs API version (instead of defaulting to 2.0)

Enables use of Databricks Jobs API 2.1 in dbx

## Proposed changes

Resolves issue [Jobs 2.1 API setting ignored by DatabricksClientProvider #378](https://github.com/databrickslabs/dbx/issues/378)

## Types of changes

What types of changes does your code introduce to dbx?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Further comments

n/a
