### PR TITLE
🩹 add escaping for the squared brackets in messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [UNRELEASED] - YYYY-MM-DD
 
+### Fixed
+
+- 🐛 Message with rich markup [] is properly displayed now
+
 ----
 > Unreleased changes must be tracked above this line.
 > When releasing, Copy the changelog to below this line, with proper version and date.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,21 +22,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.7.6] - 2022-10-05
 
-## Changed
+### Changed
+
 - ✨ Empty list of workflows is now a noop instead of throwing an error
 - 🩹 Disable the soft-wrap for printed out text
 
-## Fixed
-- 🐛 Rollback to the failsafe behaviour for assets-based property preprocessing
+### Fixed
 
+- 🐛 Rollback to the failsafe behaviour for assets-based property preprocessing
 
 ## [0.7.5] - 2022-09-15
 
-## Added
+### Added
+
 - 📖 documentation on the dependency management
 - ✨ failsafe switch for assets-based shared job clusters
 
-## Fixed
+### Fixed
+
 - 🎨 404 page in docs is now rendered correctly
 - ✏️ Small typos in the docs
 - ✏️ Reference structures for `libraries` section
@@ -44,52 +47,60 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.7.4] - 2022-08-31
 
-## Added
+### Added
+
 - 📖 documentation on the integration tests
 
-## Changed
+### Changed
+
 - ♻️ refactored poetry build logic
 
-## Fixed
+### Fixed
+
 - 📖 indents in quickstart doc
 - 📝 add integration tests to the quickstart structure
 
 ## [0.7.3] - 2022-08-29
 
-## Added
+### Added
+
 - ✨ add pip install extras option
 - 🎨 Nice spinners for long-running processes (e.g. cluster start and run tracing)
 - 🧪 Add convenient integration tests interface example
 
-## Changed
+### Changed
+
 - 📖 Small typos in Jinja docs
 - 📖 Formatting issues in cluster types doc
 
 ## [0.7.2] - 2022-08-28
 
-## Fixed
+### Fixed
+
 - 🐛 bug with context provisioning for `dbx execute`
 
 ## [0.7.1] - 2022-08-28
 
-## Added
+### Added
+
 - ⚡️`dbx destroy` command
 - ☁️ failsafe behaviour for shared clusters when assets-based launch is used
 - 📖 Documentation with cluster types guidance
 - 📖 Documentation with scheduling and orchestration links
 - 📖 Documentation for mixed-mode projects DevOps
 
-## Changed
+### Changed
+
 - ✨Add `.dbx/sync` folder to template gitignore
 - ✨Changed the dependencies from the `mlflow` to a more lightweight `mlflow-skinny` option
 - ✨Added suppression for too verbose `click` stacktraces
 - ⚡️added `execute_shell_command` fixture, improving tests performance x2
 - ⚡️added failsafe check for `get_experiment_by_name` call
 
-
 ## [0.7.0] - 2022-08-24
 
-## Added
+### Added
+
 - 🎨Switch all the CLI interfaces to `typer`
 - ✨Add `workflow-name` argument to `dbx deploy`, `dbx launch` and `dbx execute`
 - ✨Add `--workflows` argument to `dbx deploy`
@@ -103,7 +114,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - ✨Add build logic customization with `build.commands` section
 - ✨Add support for custom Python functions in Jinja templates
 
-## Changed
+### Changed
+
 - ✨Arguments `--allow-delete-unmatched`/`--disallow-delete-unmatched` were **replaced** with `--unmatched-behaviour` option.
 - 🏷️Deprecate `jobs` section and rename it to `workflows`
 - 🏷️Deprecate `job` and `jobs` options and rename it to `workflow` argument
@@ -118,68 +130,71 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - 💎Documentation framework changed from `sphinx` to `mkdocs`
 - 💎Documentation has been heavily re-worked and improved
 
-## Fixed
+### Fixed
+
 - 🐛`dbx sync` now takes into account `HTTP(S)_PROXY` env variables
 - 🐛empty task parameters are now supported
 - 🐛ACLs are now properly updated for Jobs API 2.1
 
 ## [0.6.12] - 2022-08-15
 
-## Added
+### Added
 
 - `--jinja-variables-file` for `dbx execute`
 
-## Fixed
+### Fixed
+
 - Support `jobs_api_version` values provided by config in `ApiClient` construction
 - References and wording in the Python template
 
 ## [0.6.11] - 2022-08-09
 
-## Fixed
-- Callback issue in `--jinja-variables-file` for `dbx deploy`
+### Fixed
 
+- Callback issue in `--jinja-variables-file` for `dbx deploy`
 
 ## [0.6.10] - 2022-08-04
 
-## Added
+### Added
+
 - Added support for `python_wheel_task` in `dbx execute`
 
-## Fixed
+### Fixed
+
 - Error in case when `.dbx/project.json` is non-existent
 - Error in case when `environment` is not provided in the project file
 - Path usage when `--upload-via-context` on win platform
 
 ## [0.6.9] - 2022-08-03
 
-## Added
+### Added
 
 - Additional `sync` command options (`--no-use-gitignore`, `--force-include`, etc.) for more control over what is synced.
 - Additional `init` command option `--template` was added to allow using dbx templates distributed as part of python packages.
 - Refactored the `--deployment-file` option for better modularity of the code
 - Add upload via context for `dbx execute`
 
-
 ## [0.6.8] - 2022-07-21
 
-## Fixed
+### Fixed
 
 - Tasks naming in tests imports for Python template
 
 ## [0.6.7] - 2022-07-21
 
-## Fixed
+### Fixed
 
 - Task naming and references in the Python template
 - Small typo in Python template
 
 ## [0.6.6] - 2022-07-21
 
-## Changed
+### Changed
 
 - Rename `workloads` to `tasks` in the Python package template
 - Documentation structure has been refactored
 
-## Added
+### Added
 
 - Option (`--include-output`) to include run stderr and stdout output to the console output
 - Docs describing how-to for Python packaging
@@ -188,25 +203,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.6.5] - 2022-07-19
 
-## Fixed
+### Fixed
 
 - Local build command now produces only one file in the `dist` folder
 
-## Added
+### Added
 
 - Add `dist` directory cleanup before core package build
 - Add `--job-run-log-level` option to `dbx launch` to retrieve log after trace run
 
-## Changed
+### Changed
 
 - Separate `unit-requirements.txt` file has been deleted from the template
 
 ## [0.6.4] - 2022-07-01
 
-## Fixed
+### Fixed
 
 - `RunSubmit` based launch when cloud storage is used as an artifact location
-
 
 ## [0.6.3] - 2022-06-28
 
@@ -218,11 +232,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - All invocations in Azure Pipelines template are now module-based (`python -m ...`)
 
-
 ## [0.6.2] - 2022-06-24
 
 - Fix auth ordering (now env-variables based auth has priority across any other auth methods)
-
 
 ## [0.6.1] - 2022-06-22
 
@@ -248,7 +260,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Documentation improvements for Jinja-based templates
 - Now package builds are performed with `pip` by default
 
-
 ### Fixed
 
 - Parsing of `requirements.txt` has been improved to properly handle comments in requirements files
@@ -273,7 +284,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.4.1] - 2022-03-01
 
-## Fixed
+### Fixed
 
 - Jinja2-based file recognition behaviour
 
@@ -290,7 +301,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Issue with empty paths in non-strict path adjustment logic
 - Issues with `--no-package` argument for multi-task jobs
 - Issues with named properties propagation for Jobs API 2.1
-
 
 ## [0.3.3] - 2022-02-08
 
@@ -312,6 +322,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.3.1] - 2022-01-30
 
 ### Added
+
 - Recognition of `conf/deployment.yml` file from conf directory as a default parameter
 - Remove unnecessary references of `conf/deployment.yml` in CI pipelines
 
@@ -322,6 +333,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Upgraded minimal requirements for Azure Data Factory dependent libraries
 
 ### Fixed
+
 - Provided bugfix for emoji-based messages in certain shell environments
 - Provided bugfix for cases when not all jobs are listed due to usage of Jobs API 2.1
 - Provided bugfix for cases when file names are reused multiple times
@@ -329,63 +341,74 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Provided bugfix for ADF integration that deleted pipeline-level properties
 
 ## [0.3.0] - 2022-01-04
+
 ### Added
+
 - Add support for named property of the driver instance pool name
 - Add support for built-in templates and project initialization via :code:`dbx init`
 
 ### Fixed
+
 - Provided bugfix for named property resolution in multitask-based jobs
 
-
-
 ## [0.2.2] - 2021-12-03
+
 ### Changed
+
 - Update the contribution docs with CLA
 - Update documentation about environment variables
 
 ### Added
+
 - Add support for named job properties
 - Add support for `spark_jar_task` in Azure Data Factory reflector
 
 ### Fixed
+
 - Provide bugfix for strict path resolving in the execute command
 - Provide bugfix for Azure Datafactory when using `existing_cluster_id`
 
 ## [0.2.1] - 2021-11-04
+
 ### Changed
+
 - Update `databricks-cli` dependency to 0.16.2
 - Improved code coverage
 
 ### Added
+
 - Added support for environment variables in deployment files
 
 ### Fixed
+
 - Fixed minor bug in exception text
 - Provide a bugfix for execute issue
 
 ## [0.2.0] - 2021-09-12
+
 ### Changed
+
 - Removed pydash from package dependencies, as it is not used. Still need it as a dev-requirement.
 
 ### Added
+
 - Added support for [multitask jobs](https://docs.databricks.com/data-engineering/jobs/index.html).
 - Added more explanations around DATABRICKS_HOST exception during API client initialization
 - Add strict path adjustment policy and FUSE-based path adjustment
 
-
-
-
-
 ## [0.1.6] - 2021-08-26
+
 ### Fixed
+
 - Fix issue which stripped non-pyspark libraries from a requirements file during deploys.
 - Fix issue which didn't update local package during remote execution.
 
-
 ## [0.1.5] - 2021-08-12
 ### Added
+
 - Support for [yaml-based deployment files](https://github.com/databrickslabs/dbx/issues/39).
 ### Changed
+
 - Now dbx finds the git branch name from any subdirectory in the repository.
 - Minor alterations in the documentation.
 - Altered the Changelog based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
@@ -394,70 +417,80 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `make clean install` will set you up with all that is needed.
   - `make help` to see all available commands.
 
-
 ## [0.1.4]
+
 ### Fixed
+
 - Fix issue with execute parameters passing
 - Fix issue with multi-version package upload
 
-
 ## [0.1.3]
 ### Added
+
 - Add explicit exception for artifact location change
 - Add experimental support for fixed properties' propagation from cluster policies
 
-
 ## [0.1.2]
+
 ### Added
+
 - Added Run Submit API support.
 
-
 ## [0.1.1]
+
 ### Fixed
+
 - Fixed the issue with pywin32 installation for Azure imports on win platforms.
 
-
 ## [0.1.0]
+
 ### Added
+
 - Integration with Azure Data Factory.
 ### Fixed
+
 - Some small internal behaviour fixes.
 ### Changed
+
 - Changed the behaviour of `dbx deploy --write-specs-to-file`, to make the structure of specs file compatible with environment structure.
 
-
 ## [0.0.14]
-### Added
-- Added integrated permission management, please refer to documentation for details.
 
+### Added
+
+- Added integrated permission management, please refer to documentation for details.
 
 ## [0.0.13]
 ### Added
-- Added `--write-specs-to-file` option for `dbx deploy` command.
 
+- Added `--write-specs-to-file` option for `dbx deploy` command.
 
 ## [0.0.12]
 ### Fixed
-- HotFix for execute command.
 
+- HotFix for execute command.
 
 ## [0.0.11]
 ### Changed
+
 - Made Internal refactorings after code coverage analysis.
 
-
 ## [0.0.10]
+
 ### Fixed
+
 - Fixed issue with job spec adjustment.
 
-
 ## [0.0.9]
+
 ### Changed
+
 - Finalized the CI setup for the project.
 - No code changes were done.
 - Release is required to start correct numeration in pypi.
 
-
 ## [0.0.8]
+
 ### Added
+
 - Initial public release version.

--- a/dbx/utils/__init__.py
+++ b/dbx/utils/__init__.py
@@ -9,7 +9,9 @@ from rich import reconfigure
 reconfigure(soft_wrap=True)
 
 
-def format_dbx_message(message: Any) -> str:
+def format_dbx_message(message: Any, escape_markup: bool = True) -> str:
+    if escape_markup and isinstance(message, str):
+        message = message.replace("[", r"\[")
     formatted_time = dt.datetime.now().strftime("%Y-%m-%d %H:%M:%S.%f")[:-3]
     formatted_message = f"[red]\[dbx][/red][{formatted_time}] {message}"  # noqa
     return formatted_message


### PR DESCRIPTION
## Proposed changes

Fix a rich markup `[]` escaping issue in `dbx_echo()`

Repro:

```python
In [1]: from rich import print as rich_print

# [based] part is lost
In [2]: rich_print("🐍 Building a [Python]-[based] project")
🐍 Building a [Python]- project

# all ok now
In [3]: rich_print("🐍 Building a [Python]-[based] project".replace("[", r"\["))
🐍 Building a [Python]-[based] project
```

I found this issue as our databricks job name is often in this format: `[project_name][env]_job_name`, and in the dbx deploy log, it's shown as `[project_name]_job_name` 

## Types of changes

What types of changes does your code introduce to dbx?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Further comments

