### PR TITLE
🩹 Add host cleanup logic to `dbx sync` commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,8 +12,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.8.2] - 2022-11-02
 
 ## Fixed
+
 - 🩹 Deletion logic in the workflow eraser
 - 🩹 Wheel dependency for setup has been removed
+- 🩹 Add host cleanup logic to `dbx sync` commands
 
 ## [0.8.1] - 2022-11-02
 

--- a/dbx/api/storage/mlflow_based.py
+++ b/dbx/api/storage/mlflow_based.py
@@ -1,7 +1,6 @@
 import os
 from pathlib import PurePosixPath
 from typing import Optional
-from urllib.parse import urlparse
 
 import mlflow
 from databricks_cli.sdk import WorkspaceService
@@ -12,27 +11,17 @@ from dbx.api.auth import AuthConfigProvider
 from dbx.api.client_provider import DatabricksClientProvider
 from dbx.api.configure import EnvironmentInfo
 from dbx.constants import DATABRICKS_MLFLOW_URI
+from dbx.utils.url import strip_databricks_url
 
 
 class MlflowStorageConfigurationManager:
     DATABRICKS_HOST_ENV: str = "DATABRICKS_HOST"
     DATABRICKS_TOKEN_ENV: str = "DATABRICKS_TOKEN"
 
-    @staticmethod
-    def _strip_url(url: str) -> str:
-        """
-        Mlflow API requires url to be stripped, e.g.
-        {scheme}://{netloc}/some-stuff/ shall be transformed to {scheme}://{netloc}
-        :param url: url to be stripped
-        :return: stripped url
-        """
-        parsed = urlparse(url)
-        return f"{parsed.scheme}://{parsed.netloc}"
-
     @classmethod
     def _setup_tracking_uri(cls):
         config = AuthConfigProvider.get_config()
-        os.environ[cls.DATABRICKS_HOST_ENV] = cls._strip_url(config.host)
+        os.environ[cls.DATABRICKS_HOST_ENV] = strip_databricks_url(config.host)
         os.environ[cls.DATABRICKS_TOKEN_ENV] = config.token
         mlflow.set_tracking_uri(DATABRICKS_MLFLOW_URI)
 

--- a/dbx/sync/clients.py
+++ b/dbx/sync/clients.py
@@ -1,7 +1,6 @@
 import asyncio
 import base64
 from abc import ABC, abstractmethod
-from urllib.parse import urlparse
 
 import aiohttp
 import requests
@@ -9,6 +8,7 @@ from databricks_cli.configure.provider import DatabricksConfig
 from databricks_cli.version import version as databricks_cli_version
 
 from dbx.utils import dbx_echo
+from dbx.utils.url import strip_databricks_url
 
 
 class ClientError(Exception):
@@ -28,21 +28,6 @@ def get_headers(api_token: str, sync_operation: str = "") -> dict:
     return headers
 
 
-def get_clean_host(config: DatabricksConfig) -> str:
-    """Gets a cleaned version of the host from the config, consisting of just the scheme
-    and netloc.  This omits any remaining portion of the host config, such as the path.
-    The trailing slash is intentionally omitted.
-
-    Args:
-        config (DatabricksConfig): config to extract host from
-
-    Returns:
-        str: cleaned host
-    """
-    parsed_url = urlparse(config.host)
-    return f"{parsed_url.scheme}://{parsed_url.netloc}"
-
-
 def get_user(config: DatabricksConfig) -> dict:
     """Gets information about the user associated with the token in the config.
 
@@ -54,7 +39,7 @@ def get_user(config: DatabricksConfig) -> dict:
               or isn't supported
     """
     api_token = config.token
-    host = get_clean_host(config)
+    host = strip_databricks_url(config.host)
     headers = get_headers(api_token)
     url = f"{host}/api/2.0/preview/scim/v2/Me"
     resp = requests.get(url, headers=headers, timeout=10)
@@ -174,7 +159,7 @@ class DBFSClient(BaseClient):
         check_path(base_path)
         self.base_path = "dbfs:" + base_path.rstrip("/")
         self.api_token = config.token
-        self.host = get_clean_host(config)
+        self.host = strip_databricks_url(config.host)
         self.api_base_path = f"{self.host}/api/2.0/dbfs"
         if config.insecure is None:
             self.ssl = None
@@ -232,7 +217,7 @@ class ReposClient(BaseClient):
             raise ValueError("repo_name is required")
         self.base_path = f"/Repos/{user}/{repo_name}"
         self.api_token = config.token
-        self.host = get_clean_host(config)
+        self.host = strip_databricks_url(config.host)
         self.workspace_api_base_path = f"{self.host}/api/2.0/workspace"
         self.workspace_files_api_base_path = f"{self.host}/api/2.0/workspace-files/import-file"
         if config.insecure is None:

--- a/dbx/utils/url.py
+++ b/dbx/utils/url.py
@@ -1,0 +1,12 @@
+from urllib.parse import urlparse
+
+
+def strip_databricks_url(url: str) -> str:
+    """
+    Mlflow API requires url to be stripped, e.g.
+    {scheme}://{netloc}/some-stuff/ shall be transformed to {scheme}://{netloc}
+    :param url: url to be stripped
+    :return: stripped url
+    """
+    parsed = urlparse(url)
+    return f"{parsed.scheme}://{parsed.netloc}"

--- a/tests/unit/api/storage/test_mlflow_storage.py
+++ b/tests/unit/api/storage/test_mlflow_storage.py
@@ -7,10 +7,11 @@ from pytest_mock import MockerFixture
 
 from dbx.api.storage.mlflow_based import MlflowStorageConfigurationManager
 from dbx.models.files.project import EnvironmentInfo, MlflowStorageProperties
+from dbx.utils.url import strip_databricks_url
 
 
 def test_url_strip():
-    _stripped = MlflowStorageConfigurationManager._strip_url("https://some-location.com/with/some-postfix")
+    _stripped = strip_databricks_url("https://some-location.com/with/some-postfix")
     assert _stripped == "https://some-location.com"
 
 

--- a/tests/unit/sync/clients/conftest.py
+++ b/tests/unit/sync/clients/conftest.py
@@ -8,7 +8,7 @@ from tests.unit.sync.utils import temporary_directory
 
 @pytest.fixture
 def mock_config():
-    return mocked_props(token="fake-token", host="http://fakehost.asdf/base/", insecure=None)
+    return mocked_props(token="fake-token", host="http://fakehost.asdf/?o=1234", insecure=None)
 
 
 @pytest.fixture

--- a/tests/unit/sync/clients/test_dbfs_client.py
+++ b/tests/unit/sync/clients/test_dbfs_client.py
@@ -16,7 +16,8 @@ def client(mock_config) -> DBFSClient:
 
 def test_init(client):
     assert client.api_token == "fake-token"
-    assert client.host == "http://fakehost.asdf/base"
+    assert client.host == "http://fakehost.asdf"
+    assert client.api_base_path == "http://fakehost.asdf/api/2.0/dbfs"
 
 
 def test_delete(client: DBFSClient):
@@ -27,7 +28,7 @@ def test_delete(client: DBFSClient):
     asyncio.run(client.delete(sub_path="foo/bar", session=session))
 
     assert session.post.call_count == 1
-    assert session.post.call_args[1]["url"] == "http://fakehost.asdf/base/api/2.0/dbfs/delete"
+    assert session.post.call_args[1]["url"] == "http://fakehost.asdf/api/2.0/dbfs/delete"
     assert session.post.call_args[1]["json"] == {"path": "dbfs:/tmp/foo/foo/bar"}
     assert "ssl" not in session.post.call_args[1]
     assert session.post.call_args[1]["headers"]["Authorization"] == "Bearer fake-token"
@@ -35,7 +36,7 @@ def test_delete(client: DBFSClient):
 
 
 def test_delete_secure(client: DBFSClient):
-    mock_config = mocked_props(token="fake-token", host="http://fakehost.asdf/base/", insecure=False)
+    mock_config = mocked_props(token="fake-token", host="http://fakehost.asdf/", insecure=False)
     client = DBFSClient(base_path="/tmp/foo", config=mock_config)
     session = MagicMock()
     resp = MagicMock()
@@ -44,13 +45,13 @@ def test_delete_secure(client: DBFSClient):
     asyncio.run(client.delete(sub_path="foo/bar", session=session))
 
     assert session.post.call_count == 1
-    assert session.post.call_args[1]["url"] == "http://fakehost.asdf/base/api/2.0/dbfs/delete"
+    assert session.post.call_args[1]["url"] == "http://fakehost.asdf/api/2.0/dbfs/delete"
     assert session.post.call_args[1]["json"] == {"path": "dbfs:/tmp/foo/foo/bar"}
     assert session.post.call_args[1]["ssl"] is True
 
 
 def test_delete_secure(client: DBFSClient):
-    mock_config = mocked_props(token="fake-token", host="http://fakehost.asdf/base/", insecure=True)
+    mock_config = mocked_props(token="fake-token", host="http://fakehost.asdf/", insecure=True)
     client = DBFSClient(base_path="/tmp/foo", config=mock_config)
     session = MagicMock()
     resp = MagicMock()
@@ -59,7 +60,7 @@ def test_delete_secure(client: DBFSClient):
     asyncio.run(client.delete(sub_path="foo/bar", session=session))
 
     assert session.post.call_count == 1
-    assert session.post.call_args[1]["url"] == "http://fakehost.asdf/base/api/2.0/dbfs/delete"
+    assert session.post.call_args[1]["url"] == "http://fakehost.asdf/api/2.0/dbfs/delete"
     assert session.post.call_args[1]["json"] == {"path": "dbfs:/tmp/foo/foo/bar"}
     assert session.post.call_args[1]["ssl"] is False
 
@@ -87,7 +88,7 @@ def test_delete_recursive(client: DBFSClient):
     asyncio.run(client.delete(sub_path="foo/bar", session=session, recursive=True))
 
     assert session.post.call_count == 1
-    assert session.post.call_args[1]["url"] == "http://fakehost.asdf/base/api/2.0/dbfs/delete"
+    assert session.post.call_args[1]["url"] == "http://fakehost.asdf/api/2.0/dbfs/delete"
     assert session.post.call_args[1]["json"] == {"path": "dbfs:/tmp/foo/foo/bar", "recursive": True}
 
 
@@ -106,7 +107,7 @@ def test_delete_rate_limited(client: DBFSClient):
     asyncio.run(client.delete(sub_path="foo/bar", session=session))
 
     assert session.post.call_count == 2
-    assert session.post.call_args[1]["url"] == "http://fakehost.asdf/base/api/2.0/dbfs/delete"
+    assert session.post.call_args[1]["url"] == "http://fakehost.asdf/api/2.0/dbfs/delete"
     assert session.post.call_args[1]["json"] == {"path": "dbfs:/tmp/foo/foo/bar"}
 
 
@@ -125,7 +126,7 @@ def test_delete_rate_limited_retry_after(client: DBFSClient):
     asyncio.run(client.delete(sub_path="foo/bar", session=session))
 
     assert session.post.call_count == 2
-    assert session.post.call_args[1]["url"] == "http://fakehost.asdf/base/api/2.0/dbfs/delete"
+    assert session.post.call_args[1]["url"] == "http://fakehost.asdf/api/2.0/dbfs/delete"
     assert session.post.call_args[1]["json"] == {"path": "dbfs:/tmp/foo/foo/bar"}
 
 
@@ -151,7 +152,7 @@ def test_mkdirs(client: DBFSClient):
     asyncio.run(client.mkdirs(sub_path="foo/bar", session=session))
 
     assert session.post.call_count == 1
-    assert session.post.call_args[1]["url"] == "http://fakehost.asdf/base/api/2.0/dbfs/mkdirs"
+    assert session.post.call_args[1]["url"] == "http://fakehost.asdf/api/2.0/dbfs/mkdirs"
     assert session.post.call_args[1]["json"] == {"path": "dbfs:/tmp/foo/foo/bar"}
     assert session.post.call_args[1]["headers"]["Authorization"] == "Bearer fake-token"
     assert is_dbfs_user_agent(session.post.call_args[1]["headers"]["user-agent"])
@@ -187,7 +188,7 @@ def test_mkdirs_rate_limited(client: DBFSClient):
     asyncio.run(client.mkdirs(sub_path="foo/bar", session=session))
 
     assert session.post.call_count == 2
-    assert session.post.call_args[1]["url"] == "http://fakehost.asdf/base/api/2.0/dbfs/mkdirs"
+    assert session.post.call_args[1]["url"] == "http://fakehost.asdf/api/2.0/dbfs/mkdirs"
     assert session.post.call_args[1]["json"] == {"path": "dbfs:/tmp/foo/foo/bar"}
 
 
@@ -206,7 +207,7 @@ def test_mkdirs_rate_limited_retry_after(client: DBFSClient):
     asyncio.run(client.mkdirs(sub_path="foo/bar", session=session))
 
     assert session.post.call_count == 2
-    assert session.post.call_args[1]["url"] == "http://fakehost.asdf/base/api/2.0/dbfs/mkdirs"
+    assert session.post.call_args[1]["url"] == "http://fakehost.asdf/api/2.0/dbfs/mkdirs"
     assert session.post.call_args[1]["json"] == {"path": "dbfs:/tmp/foo/foo/bar"}
 
 
@@ -233,7 +234,7 @@ def test_put(client: DBFSClient, dummy_file_path: str):
     asyncio.run(client.put(sub_path="foo/bar", full_source_path=dummy_file_path, session=session))
 
     assert session.post.call_count == 1
-    assert session.post.call_args[1]["url"] == "http://fakehost.asdf/base/api/2.0/dbfs/put"
+    assert session.post.call_args[1]["url"] == "http://fakehost.asdf/api/2.0/dbfs/put"
     assert session.post.call_args[1]["json"] == {
         "path": "dbfs:/tmp/foo/foo/bar",
         "contents": base64.b64encode(b"yo").decode("ascii"),
@@ -275,7 +276,7 @@ def test_put_rate_limited(client: DBFSClient, dummy_file_path: str):
     asyncio.run(client.put(sub_path="foo/bar", full_source_path=dummy_file_path, session=session))
 
     assert session.post.call_count == 2
-    assert session.post.call_args[1]["url"] == "http://fakehost.asdf/base/api/2.0/dbfs/put"
+    assert session.post.call_args[1]["url"] == "http://fakehost.asdf/api/2.0/dbfs/put"
     assert session.post.call_args[1]["json"] == {
         "path": "dbfs:/tmp/foo/foo/bar",
         "contents": base64.b64encode(b"yo").decode("ascii"),
@@ -298,7 +299,7 @@ def test_put_rate_limited_retry_after(client: DBFSClient, dummy_file_path: str):
     asyncio.run(client.put(sub_path="foo/bar", full_source_path=dummy_file_path, session=session))
 
     assert session.post.call_count == 2
-    assert session.post.call_args[1]["url"] == "http://fakehost.asdf/base/api/2.0/dbfs/put"
+    assert session.post.call_args[1]["url"] == "http://fakehost.asdf/api/2.0/dbfs/put"
     assert session.post.call_args[1]["json"] == {
         "path": "dbfs:/tmp/foo/foo/bar",
         "contents": base64.b64encode(b"yo").decode("ascii"),

--- a/tests/unit/sync/clients/test_get_user.py
+++ b/tests/unit/sync/clients/test_get_user.py
@@ -1,10 +1,24 @@
 from unittest.mock import MagicMock, PropertyMock, patch
 
+import pytest
+
 from dbx.sync.clients import get_user
+from tests.unit.sync.utils import mocked_props
 
 
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        ("http://fakehost.asdf", "http://fakehost.asdf/api/2.0/preview/scim/v2/Me"),
+        ("http://fakehost.asdf/", "http://fakehost.asdf/api/2.0/preview/scim/v2/Me"),
+        ("http://fakehost.asdf/?o=1234", "http://fakehost.asdf/api/2.0/preview/scim/v2/Me"),
+        ("http://fakehost.asdf:8080/?o=1234", "http://fakehost.asdf:8080/api/2.0/preview/scim/v2/Me"),
+    ],
+)
 @patch("dbx.sync.clients.requests")
-def test_get_user(mock_requests, mock_config):
+def test_get_user(mock_requests, test_case):
+    config_host, expected_url = test_case
+    mock_config = mocked_props(token="fake-token", host=config_host, insecure=None)
     resp = MagicMock()
     setattr(type(resp), "status_code", PropertyMock(return_value=200))
     user_info = {"userName": "foo"}
@@ -12,6 +26,7 @@ def test_get_user(mock_requests, mock_config):
     mock_requests.get.return_value = resp
     assert get_user(mock_config) == user_info
     assert resp.json.call_count == 1
+    assert mock_requests.get.call_args[0][0] == expected_url
 
 
 @patch("dbx.sync.clients.requests")


### PR DESCRIPTION
## Proposed changes

This is a fix for #551.  `dbx sync` does not currently work correctly if the host in the config has a query param.  Other dbx commands work fine because they use the [ApiClient](https://github.com/databricks/databricks-cli/blob/main/databricks_cli/sdk/api_client.py#L116) (see [here](https://github.com/databrickslabs/dbx/blob/56a9ed5ef5b5698b1f17e470a77ac3229934f096/dbx/api/client_provider.py#L51)), which parses the host and formats the URL using only the scheme and hostname.  The sync command uses the raw host and formats it with the API path.

Here I apply the same approach for the dbx sync client code by using `urlparse` to parse the host from the config and formatting a clean version that can be combined with the API paths. 

## Types of changes

What types of changes does your code introduce to dbx?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Further comments

Aside from updating the unit tests to cover the changes, I also ran a `dbx sync repo` command with an old version of the code and query param appended.  I confirmed this did not work.  I then tested the new version of the code and confirmed the sync command worked.
