### PR TITLE
Check if repo exists first

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 # Fixed
 
 - 🩹 Reload config after build in case if there are any dynamic components dependent on it
+- 🩹 Check if target repo exists before syncing and produce more clear error message if it does not.
 
 ## [0.8.7] - 2022-11-14
 


### PR DESCRIPTION
## Proposed changes

This addresses #582.  Current if `dbx sync repo` is used to sync to a repo that does not exist it results in a cryptic error.  This improves the situation by checking if the repo exists before starting the main loop and providing a more helpful error message.

## Types of changes

What types of changes does your code introduce to dbx?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Further comments

Besides updating unit tests, I also tested this by running `dbx sync repo -d foo`, where `foo` doesn't exist.  It results in the error below.  I also tried with a repo that does exist and confirmed it still works.

```
Destination repo foo does not exist.  Please create the repo using the Databricks UI and try again.  You can create an empty repo by clicking 'Add Repo', unchecking the 'Create repo by cloning a Git repository' option, and providing foo as the repository name.              
```
