### PR TITLE
🩹 fix #622 dbx deploy --no-package without building wheel file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - 🩹 Type recognition of `named_parameters` in `python_wheel_task`
 - 🔨 Add support for extras for cloud file operations
 - 🔨 `warehouse_id` field in dbt task is optional now.
+- 🔨 `dbx deploy --no-package` won't build wheel package.
 
 ## [0.8.7] - 2022-11-14
 

--- a/dbx/commands/deploy.py
+++ b/dbx/commands/deploy.py
@@ -6,30 +6,30 @@ from typing import Optional
 import mlflow
 import typer
 
-from dbx.api.adjuster.adjuster import Adjuster, AdditionalLibrariesProvider
-from dbx.api.config_reader import ConfigReader, BuildProperties
+from dbx.api.adjuster.adjuster import AdditionalLibrariesProvider, Adjuster
+from dbx.api.config_reader import BuildProperties, ConfigReader
 from dbx.api.dependency.core_package import CorePackageManager
 from dbx.api.dependency.requirements import RequirementsFileProcessor
 from dbx.api.deployment import WorkflowDeploymentManager
 from dbx.api.storage.io import StorageIO
 from dbx.models.workflow.common.workflow_types import WorkflowType
 from dbx.options import (
+    BRANCH_NAME_OPTION,
+    DEBUG_OPTION,
     DEPLOYMENT_FILE_OPTION,
     ENVIRONMENT_OPTION,
     JINJA_VARIABLES_FILE_OPTION,
-    REQUIREMENTS_FILE_OPTION,
-    NO_REBUILD_OPTION,
     NO_PACKAGE_OPTION,
+    NO_REBUILD_OPTION,
+    REQUIREMENTS_FILE_OPTION,
     TAGS_OPTION,
-    BRANCH_NAME_OPTION,
-    DEBUG_OPTION,
     WORKFLOW_ARGUMENT,
 )
 from dbx.utils import dbx_echo
 from dbx.utils.common import (
-    prepare_environment,
-    parse_multiple,
     get_current_branch_name,
+    parse_multiple,
+    prepare_environment,
 )
 from dbx.utils.file_uploader import MlflowFileUploader
 
@@ -115,7 +115,7 @@ def deploy(
     deployable_workflows = environment_info.payload.select_relevant_or_all_workflows(workflow_name, workflow_names)
     environment_info.payload.workflows = deployable_workflows  # filter out the chosen set of workflows
 
-    core_package = CorePackageManager().core_package
+    core_package = None if no_package else CorePackageManager().core_package
     libraries_from_requirements = RequirementsFileProcessor(requirements_file).libraries if requirements_file else []
 
     _assets_only = assets_only if assets_only else files_only


### PR DESCRIPTION
## Proposed changes

When deploying pure notebooks, project might not have setup.py or pyproject.toml file, so cannot build the wheel package.

## Types of changes

What types of changes does your code introduce to dbx?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Further comments

minor change
