### PR TITLE
:sparkles: Add support for additional headers

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -10,10 +10,14 @@ RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
 
 # Configure pyenv
 USER vscode
+ENV HOME /home/vscode
+ENV PYENV_ROOT $HOME/.pyenv
+ENV PATH $PYENV_ROOT/shims:$PYENV_ROOT/bin:$PATH
 RUN curl https://pyenv.run | bash
-RUN echo 'export PYENV_ROOT="/workspaces/dbx/.venv"' >> $HOME/.bashrc
+RUN echo 'export PYENV_ROOT="$HOME/.pyenv"' >> ~/.bashrc
 RUN echo 'command -v pyenv >/dev/null || export PATH="$PYENV_ROOT/bin:$PATH"' >> ~/.bashrc
-RUN echo eval "$($HOME/.pyenv/bin/pyenv init -)" >> $HOME/.bashrc
-RUN . ${HOME}/.bashrc \
-   && $HOME/.pyenv/bin/pyenv install 3.8.13 \
-   && $HOME/.pyenv/bin/pyenv global 3.8.13
+RUN echo eval "$(pyenv init -)" >> ~/.bashrc
+SHELL ["/bin/bash", "-c"]
+RUN . ~/.bashrc \
+   && pyenv install 3.8.13 \
+   && pyenv global 3.8.13

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -9,15 +9,18 @@
 			// Update 'VARIANT' to pick a Python version: 3, 3.10, 3.9, 3.8, 3.7, 3.6
 			// Append -bullseye or -buster to pin to an OS version.
 			// Use -bullseye variants on local on arm64/Apple Silicon.
-			"VARIANT": "3.10-bullseye",
+			"VARIANT": "3.10-bullseye"
 		}
 	},
 	// For VSCode local bind mount ~/.databrickscfg to persist the config
 	"initializeCommand": "touch $HOME/.databrickscfg",
 	"mounts": [
 		// mount databricks config
-		"source=${localEnv:HOME}/.databrickscfg,target=/home/vscode/.databrickscfg,type=bind,consistency=cached"
+		"source=${localEnv:HOME}/.databrickscfg,target=/home/vscode/.databrickscfg,type=bind,consistency=cached",
+		"source=/mnt/c/Users/B119752/repos/pebe-databricks,target=/home/vscode/pebe-databricks,type=bind"
 	],
+	"workspaceMount": "source=${localWorkspaceFolder},target=/workspaces/dbx,type=bind,consistency=cached",
+	"workspaceFolder": "/workspaces/dbx",
 	// Configure tool-specific properties.
 	"customizations": {
 		// Configure properties specific to VS Code.
@@ -35,7 +38,7 @@
 				"python.linting.mypyPath": "/usr/local/py-utils/bin/mypy",
 				"python.linting.pycodestylePath": "/usr/local/py-utils/bin/pycodestyle",
 				"python.linting.pydocstylePath": "/usr/local/py-utils/bin/pydocstyle",
-				"python.linting.pylintPath": "/usr/local/py-utils/bin/pylint",
+				"python.linting.pylintPath": "pylint",
 				"python.testing.unittestArgs": [
 					"-v",
 					"-s",
@@ -46,11 +49,14 @@
 				"python.testing.pytestEnabled": false,
 				"python.testing.unittestEnabled": true,
 				"editor.formatOnSave": true,
-				"python.formatting.provider": "black"
+				"python.formatting.provider": "black",
+				"editor.defaultFormatter": "ms-python.black-formatter"
 			},
 			// Add the IDs of extensions you want installed when the container is created.
 			"extensions": [
 				"ms-python.python",
+				"ms-python.pylint",
+				"ms-python.black-formatter",
 				"ms-python.vscode-pylance",
 				"ms-vscode.makefile-tools"
 			]

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -16,8 +16,7 @@
 	"initializeCommand": "touch $HOME/.databrickscfg",
 	"mounts": [
 		// mount databricks config
-		"source=${localEnv:HOME}/.databrickscfg,target=/home/vscode/.databrickscfg,type=bind,consistency=cached",
-		"source=/mnt/c/Users/B119752/repos/pebe-databricks,target=/home/vscode/pebe-databricks,type=bind"
+		"source=${localEnv:HOME}/.databrickscfg,target=/home/vscode/.databrickscfg,type=bind,consistency=cached"
 	],
 	"workspaceMount": "source=${localWorkspaceFolder},target=/workspaces/dbx,type=bind,consistency=cached",
 	"workspaceFolder": "/workspaces/dbx",
@@ -29,6 +28,7 @@
 			"settings": {
 				"python.defaultInterpreterPath": "/usr/local/bin/python",
 				"python.linting.enabled": true,
+				"python.languageServer": "Pylance",
 				"python.formatting.autopep8Path": "/usr/local/py-utils/bin/autopep8",
 				"python.formatting.blackPath": "/usr/local/py-utils/bin/black",
 				"python.formatting.yapfPath": "/usr/local/py-utils/bin/yapf",
@@ -55,8 +55,8 @@
 			// Add the IDs of extensions you want installed when the container is created.
 			"extensions": [
 				"ms-python.python",
-				"ms-python.black-formatter",
 				"ms-python.vscode-pylance",
+				"ms-python.black-formatter",
 				"ms-vscode.makefile-tools"
 			]
 		}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -29,7 +29,6 @@
 			"settings": {
 				"python.defaultInterpreterPath": "/usr/local/bin/python",
 				"python.linting.enabled": true,
-				"python.linting.pylintEnabled": true,
 				"python.formatting.autopep8Path": "/usr/local/py-utils/bin/autopep8",
 				"python.formatting.blackPath": "/usr/local/py-utils/bin/black",
 				"python.formatting.yapfPath": "/usr/local/py-utils/bin/yapf",
@@ -50,12 +49,12 @@
 				"python.testing.unittestEnabled": true,
 				"editor.formatOnSave": true,
 				"python.formatting.provider": "black",
-				"editor.defaultFormatter": "ms-python.black-formatter"
+				"editor.defaultFormatter": "ms-python.black-formatter",
+				"python.linting.prospectorEnabled": true
 			},
 			// Add the IDs of extensions you want installed when the container is created.
 			"extensions": [
 				"ms-python.python",
-				"ms-python.pylint",
 				"ms-python.black-formatter",
 				"ms-python.vscode-pylance",
 				"ms-vscode.makefile-tools"

--- a/Makefile
+++ b/Makefile
@@ -149,7 +149,6 @@ install-dev: ## Install dev dependencies.
 	@echo "${YELLOW}Install Dev dependencies.${NORMAL}"
 	@make helper-line
 	$(PYTHON) -m pip install -e ".[dev]"
-	pre-commit install
 
 post-install-info: ## Just some post installation info.
 	@echo ""

--- a/dbx/api/auth.py
+++ b/dbx/api/auth.py
@@ -1,48 +1,67 @@
 import os
 from functools import lru_cache
-from typing import List, Optional
+from typing import List, Optional, Protocol, Union
 
 from databricks_cli.configure.provider import (
     DatabricksConfig,
-    ProfileConfigProvider,
     DatabricksConfigProvider,
+    _fetch_from_fs,
+    _get_option_if_exists,
+    HOST,
+    USERNAME,
+    PASSWORD,
+    TOKEN,
+    REFRESH_TOKEN,
+    INSECURE,
+    JOBS_API_VERSION,
+    DEFAULT_SECTION,
 )
 
 from dbx.utils import dbx_echo
 
 
+AZURE_SERVICE_PRINCIPAL_TOKEN = "azure_service_principal_token"
+WORKSPACE_ID = "workspace_id"
+ORG_ID = "org_id"
+
+
 class DbxConfig(DatabricksConfig):
     def __init__(
         self,
-        host,
-        username,
-        password,
-        token,
-        refresh_token=None,
-        insecure=None,
-        jobs_api_version=None,
-        azure_ad_token=None,
-        workspace_id=None,
-        org_id=None,
+        host: str,
+        username: str,
+        password: str,
+        token: str,
+        refresh_token: Optional[str] = None,
+        insecure: Optional[Union[bool, str]] = None,
+        jobs_api_version: Optional[str] = None,
+        azure_sp_token: Optional[str] = None,
+        workspace_id: Optional[str] = None,
+        org_id: Optional[str] = None,
     ):  # noqa
         super().__init__(host, username, password, token, refresh_token, insecure, jobs_api_version)
         _headers = {
-            "X-Databricks-Azure-SP-Management-Token": azure_ad_token,
+            "X-Databricks-Azure-SP-Management-Token": azure_sp_token,
             "X-Databricks-Azure-Workspace-Resource-Id": workspace_id,
             "X-Databricks-Org-Id": org_id,
         }
         self.headers = {k: v for k, v in _headers.items() if v is not None}
 
 
+class DbxConfigProvider(Protocol):
+    def get_config(self) -> Union[DbxConfig, None]:
+        ...
+
+
 class DbxEnvironmentVariableConfigProvider(DatabricksConfigProvider):
     """Loads from system environment variables."""
 
-    def get_config(self):
+    def get_config(self) -> Union[DbxConfig, None]:
         host = os.environ.get("DATABRICKS_HOST")
         username = os.environ.get("DATABRICKS_USERNAME")
         password = os.environ.get("DATABRICKS_PASSWORD")
         token = os.environ.get("DATABRICKS_TOKEN")
-        azure_ad_token = os.environ.get("AAD_TOKEN")
+        azure_sp_token = os.environ.get("AZURE_SERVICE_PRINCIPAL_TOKEN")
         refresh_token = os.environ.get("DATABRICKS_REFRESH_TOKEN")
         insecure = os.environ.get("DATABRICKS_INSECURE")
         jobs_api_version = os.environ.get("DATABRICKS_JOBS_API_VERSION")
@@ -56,7 +75,42 @@ class DbxEnvironmentVariableConfigProvider(DatabricksConfigProvider):
             refresh_token,
             insecure,
             jobs_api_version,
-            azure_ad_token,
+            azure_sp_token,
+            workspace_id,
+            org_id,
+        )
+        if config.is_valid:
+            return config
+        return None
+
+
+class DbxProfileConfigProvider(DatabricksConfigProvider):
+    """Loads from the databrickscfg file."""
+
+    def __init__(self, profile=DEFAULT_SECTION):
+        self.profile = profile
+
+    def get_config(self) -> Union[DbxConfig, None]:
+        raw_config = _fetch_from_fs()
+        host = _get_option_if_exists(raw_config, self.profile, HOST)
+        username = _get_option_if_exists(raw_config, self.profile, USERNAME)
+        password = _get_option_if_exists(raw_config, self.profile, PASSWORD)
+        token = _get_option_if_exists(raw_config, self.profile, TOKEN)
+        refresh_token = _get_option_if_exists(raw_config, self.profile, REFRESH_TOKEN)
+        insecure = _get_option_if_exists(raw_config, self.profile, INSECURE)
+        jobs_api_version = _get_option_if_exists(raw_config, self.profile, JOBS_API_VERSION)
+        azure_sp_token = _get_option_if_exists(raw_config, self.profile, AZURE_SERVICE_PRINCIPAL_TOKEN)
+        workspace_id = _get_option_if_exists(raw_config, self.profile, WORKSPACE_ID)
+        org_id = _get_option_if_exists(raw_config, self.profile, ORG_ID)
+        config = DbxConfig(
+            host,
+            username,
+            password,
+            token,
+            refresh_token,
+            insecure,
+            jobs_api_version,
+            azure_sp_token,
             workspace_id,
             org_id,
         )
@@ -73,7 +127,7 @@ class ProfileEnvConfigProvider(DatabricksConfigProvider):
 
     def get_config(self) -> Optional[DatabricksConfig]:
         profile = self._get_profile_name()
-        _config = None if not profile else ProfileConfigProvider(profile).get_config()
+        _config = None if not profile else DbxProfileConfigProvider(profile).get_config()
         return _config
 
     @classmethod
@@ -97,14 +151,12 @@ class AuthConfigProvider:
     @staticmethod
     def _get_config_from_env() -> Optional[DbxConfig]:
         config = DbxEnvironmentVariableConfigProvider().get_config()
-        if config:
-            AuthConfigProvider._verify_config_validity(config)
-            return config
+        return config
 
     @classmethod
     @lru_cache(maxsize=None)
     def get_config(cls) -> DbxConfig:
-        providers: List[DatabricksConfigProvider] = [
+        providers: List[DbxConfigProvider] = [
             DbxEnvironmentVariableConfigProvider(),
             ProfileEnvConfigProvider(),
         ]

--- a/dbx/api/client_provider.py
+++ b/dbx/api/client_provider.py
@@ -45,27 +45,30 @@ class DatabricksClientProvider:
     """
 
     @classmethod
-    def _get_v2_client(cls) -> ApiClient:
+    def _get_v2_client(cls, default_headers: Dict[str, Any] = None) -> ApiClient:
         config = AuthConfigProvider.get_config()
         verify = config.insecure is None
+        if default_headers is None:
+            default_headers = {}
         _client = ApiClient(
             host=config.host,
             token=config.token,
             jobs_api_version=config.jobs_api_version,
             verify=verify,
+            default_headers=default_headers,
             command_name="cicdtemplates-",
         )
         return _client
 
     @classmethod
-    def _get_v1_client(cls) -> ApiV1Client:
-        _client = ApiV1Client(cls._get_v2_client())
+    def _get_v1_client(cls, default_headers: Dict[str, Any] = None) -> ApiV1Client:
+        _client = ApiV1Client(cls._get_v2_client(default_headers))
         return _client
 
     @classmethod
-    def get_v2_client(cls) -> ApiClient:
-        return cls._get_v2_client()
+    def get_v2_client(cls, default_headers: Dict[str, Any] = None) -> ApiClient:
+        return cls._get_v2_client(default_headers)
 
     @classmethod
-    def get_v1_client(cls) -> ApiV1Client:
-        return cls._get_v1_client()
+    def get_v1_client(cls, default_headers: Dict[str, Any] = None) -> ApiV1Client:
+        return cls._get_v1_client(default_headers)

--- a/dbx/api/client_provider.py
+++ b/dbx/api/client_provider.py
@@ -1,5 +1,5 @@
 import copy
-from typing import Dict, Any
+from typing import Dict, Any, Optional
 
 import requests
 from databricks_cli.sdk import ApiClient
@@ -45,7 +45,7 @@ class DatabricksClientProvider:
     """
 
     @classmethod
-    def _get_v2_client(cls, headers: Dict[str, str] = None) -> ApiClient:
+    def _get_v2_client(cls, headers: Optional[Dict[str, str]] = None) -> ApiClient:
         config = AuthConfigProvider.get_config()
         verify = config.insecure is None
         if headers is None:
@@ -61,14 +61,14 @@ class DatabricksClientProvider:
         return _client
 
     @classmethod
-    def _get_v1_client(cls, headers: Dict[str, str] = None) -> ApiV1Client:
+    def _get_v1_client(cls, headers: Optional[Dict[str, str]] = None) -> ApiV1Client:
         _client = ApiV1Client(cls._get_v2_client(headers))
         return _client
 
     @classmethod
-    def get_v2_client(cls, headers: Dict[str, str] = None) -> ApiClient:
+    def get_v2_client(cls, headers: Optional[Dict[str, str]] = None) -> ApiClient:
         return cls._get_v2_client(headers)
 
     @classmethod
-    def get_v1_client(cls, headers: Dict[str, str] = None) -> ApiV1Client:
+    def get_v1_client(cls, headers: Optional[Dict[str, str]] = None) -> ApiV1Client:
         return cls._get_v1_client(headers)

--- a/dbx/api/client_provider.py
+++ b/dbx/api/client_provider.py
@@ -45,30 +45,30 @@ class DatabricksClientProvider:
     """
 
     @classmethod
-    def _get_v2_client(cls, default_headers: Dict[str, Any] = None) -> ApiClient:
+    def _get_v2_client(cls, headers: Dict[str, str] = None) -> ApiClient:
         config = AuthConfigProvider.get_config()
         verify = config.insecure is None
-        if default_headers is None:
-            default_headers = {}
+        if headers is None:
+            headers = config.headers
         _client = ApiClient(
             host=config.host,
             token=config.token,
             jobs_api_version=config.jobs_api_version,
             verify=verify,
-            default_headers=default_headers,
+            default_headers=headers,
             command_name="cicdtemplates-",
         )
         return _client
 
     @classmethod
-    def _get_v1_client(cls, default_headers: Dict[str, Any] = None) -> ApiV1Client:
-        _client = ApiV1Client(cls._get_v2_client(default_headers))
+    def _get_v1_client(cls, headers: Dict[str, str] = None) -> ApiV1Client:
+        _client = ApiV1Client(cls._get_v2_client(headers))
         return _client
 
     @classmethod
-    def get_v2_client(cls, default_headers: Dict[str, Any] = None) -> ApiClient:
-        return cls._get_v2_client(default_headers)
+    def get_v2_client(cls, headers: Dict[str, str] = None) -> ApiClient:
+        return cls._get_v2_client(headers)
 
     @classmethod
-    def get_v1_client(cls, default_headers: Dict[str, Any] = None) -> ApiV1Client:
-        return cls._get_v1_client(default_headers)
+    def get_v1_client(cls, headers: Dict[str, str] = None) -> ApiV1Client:
+        return cls._get_v1_client(headers)

--- a/dbx/cli.py
+++ b/dbx/cli.py
@@ -99,12 +99,12 @@ app.command(
 
     9. If `--write-specs-to-file` option is provided, writes the final workload definition into a given file.
     
-    10. If option `--default-headers <TEXT>` or `-H <TEXT>` is provided, parses contents of <TEXT> as a JSON object and adds
-        the key-value pairs as additional headers for the API calls.<br/>
+    10. If option `--header <TEXT>` or `-H <TEXT>` is provided, parses contents of <TEXT> as a key-value pair and
+        appends it to the headers for the API calls.<br/>
         Examples:
         ```
-        dbx deploy [OPTIONS] --default-headers '{"Some-Header-KeyWord": "Sample value", "Extra-Header": 42}'
-        dbx deploy [OPTIONS] -H '{"Some-Header-KeyWord": "Sample value", "Extra-Header": 42}'
+        dbx deploy [OPTIONS] --header name1=value1 --header name2=value2
+        dbx deploy [OPTIONS] -H name1=value1 -H name2=value2
         ```""",
 )(deploy)
 
@@ -132,16 +132,18 @@ app.command(
     5. Code will be executed in a separate context. Other users can work with the same package
        on the same cluster without any limitations or overlapping.
     6. Execution results will be printed out in the shell. If result was an error, command will have error exit code.
-    7. If option `--default-headers <TEXT>` or `-H <TEXT>` is provided, parses contents of <TEXT> as a JSON object and adds
-       the key-value pairs as additional headers for the API calls.<br/>
+    7. If option `--header <TEXT>` or `-H <TEXT>` is provided, parses contents of <TEXT> as a key-value pair and
+       appends it to the headers for the API calls.<br/>
        Examples:
        ```
-       dbx execute [OPTIONS] --default-headers '{"Some-Header-KeyWord": "Sample value", "Extra-Header": 42}'
-       dbx execute [OPTIONS] -H '{"Some-Header-KeyWord": "Sample value", "Extra-Header": 42}'
+       dbx deploy [OPTIONS] --header name1=value1 --header name2=value2
+       dbx deploy [OPTIONS] -H name1=value1 -H name2=value2
        ```""",
 )(execute)
 
-app.command(short_help="💎 Generates new project from the template.", help="💎 Generates new project from the template.")(init)
+app.command(short_help="💎 Generates new project from the template.", help="💎 Generates new project from the template.")(
+    init
+)
 
 app.command(
     short_help="🚀 Launch the workflow on a job cluster.",
@@ -180,12 +182,12 @@ app.command(
     the [Jobs RunNow API](https://docs.databricks.com/dev-tools/api/latest/jobs.html#operation/JobsRunNow).
     
 
-    If option `--default-headers <TEXT>` or `-H <TEXT>` is provided, parses contents of <TEXT> as a JSON object and adds
-    the key-value pairs as additional headers for the API calls.<br/>
+    If option `--header <TEXT>` or `-H <TEXT>` is provided, parses contents of <TEXT> as a key-value pair and
+    appends it to the headers for the API calls.<br/>
     Examples:
     ```
-    dbx launch [OPTIONS] --default-headers '{"Some-Header-KeyWord": "Sample value", "Extra-Header": 42}'
-    dbx launch [OPTIONS] -H '{"Some-Header-KeyWord": "Sample value", "Extra-Header": 42}'
+    dbx deploy [OPTIONS] --header name1=value1 --header name2=value2
+    dbx deploy [OPTIONS] -H name1=value1 -H name2=value2
     ```""",
 )(launch)
 
@@ -201,12 +203,12 @@ app.command(
     🚨 If neither workflow argument nor `--workflows` option are provided,
     will destroy **all** workflows defined in the deployment file.
     
-    If option `--default-headers <TEXT>` or `-H <TEXT>` is provided, parses contents of <TEXT> as a JSON object and adds
-    the key-value pairs as additional headers for the API calls.<br/>
+    If option `--header <TEXT>` or `-H <TEXT>` is provided, parses contents of <TEXT> as a key-value pair and
+    appends it to the headers for the API calls.<br/>
     Examples:
     ```
-    dbx destroy [OPTIONS] --default-headers '{"Some-Header-KeyWord": "Sample value", "Extra-Header": 42}'
-    dbx destroy [OPTIONS] -H '{"Some-Header-KeyWord": "Sample value", "Extra-Header": 42}'
+    dbx deploy [OPTIONS] --header name1=value1 --header name2=value2
+    dbx deploy [OPTIONS] -H name1=value1 -H name2=value2
     ```""",
     name="destroy",
 )(destroy)

--- a/dbx/cli.py
+++ b/dbx/cli.py
@@ -1,4 +1,5 @@
 import click
+import typer
 import typer.rich_utils
 from rich.traceback import install
 
@@ -96,7 +97,15 @@ app.command(
        ℹ️ In some cases (e.g. when Git head is `DETACHED`), we won't be able to identity the branch name.<br/>
        Please use `--tags` and `--branch-name` options if you notice that workflow definitions are inconsistent.
 
-    9. If `--write-specs-to-file` option is provided, writes the final workload definition into a given file.""",
+    9. If `--write-specs-to-file` option is provided, writes the final workload definition into a given file.
+    
+    10. If option `--default-headers <TEXT>` or `-H <TEXT>` is provided, parses contents of <TEXT> as a JSON object and adds
+        the key-value pairs as additional headers for the API calls.<br/>
+        Examples:
+        ```
+        dbx deploy [OPTIONS] --default-headers '{"Some-Header-KeyWord": "Sample value", "Extra-Header": 42}'
+        dbx deploy [OPTIONS] -H '{"Some-Header-KeyWord": "Sample value", "Extra-Header": 42}'
+        ```""",
 )(deploy)
 
 app.command(
@@ -123,12 +132,16 @@ app.command(
     5. Code will be executed in a separate context. Other users can work with the same package
        on the same cluster without any limitations or overlapping.
     6. Execution results will be printed out in the shell. If result was an error, command will have error exit code.
-    """,
+    7. If option `--default-headers <TEXT>` or `-H <TEXT>` is provided, parses contents of <TEXT> as a JSON object and adds
+       the key-value pairs as additional headers for the API calls.<br/>
+       Examples:
+       ```
+       dbx execute [OPTIONS] --default-headers '{"Some-Header-KeyWord": "Sample value", "Extra-Header": 42}'
+       dbx execute [OPTIONS] -H '{"Some-Header-KeyWord": "Sample value", "Extra-Header": 42}'
+       ```""",
 )(execute)
 
-app.command(short_help="💎 Generates new project from the template.", help="💎 Generates new project from the template.")(
-    init
-)
+app.command(short_help="💎 Generates new project from the template.", help="💎 Generates new project from the template.")(init)
 
 app.command(
     short_help="🚀 Launch the workflow on a job cluster.",
@@ -164,7 +177,16 @@ app.command(
     When `dbx launch` is running without `--from-assets` option,
     it will simply find the job by it's name and start a new job run.
     In this case `dbx launch` will use
-    the [Jobs RunNow API](https://docs.databricks.com/dev-tools/api/latest/jobs.html#operation/JobsRunNow).""",
+    the [Jobs RunNow API](https://docs.databricks.com/dev-tools/api/latest/jobs.html#operation/JobsRunNow).
+    
+
+    If option `--default-headers <TEXT>` or `-H <TEXT>` is provided, parses contents of <TEXT> as a JSON object and adds
+    the key-value pairs as additional headers for the API calls.<br/>
+    Examples:
+    ```
+    dbx launch [OPTIONS] --default-headers '{"Some-Header-KeyWord": "Sample value", "Extra-Header": 42}'
+    dbx launch [OPTIONS] -H '{"Some-Header-KeyWord": "Sample value", "Extra-Header": 42}'
+    ```""",
 )(launch)
 
 app.add_typer(
@@ -176,8 +198,16 @@ app.command(
     short_help="🚮 Delete defined workflows and relevant assets.",
     help="""🚮 Delete defined workflows and relevant assets.
 
-    🚨 If neither workflow argument not `--workflows` option are provided,
-    will destroy **all** workflows defined in the deployment file.""",
+    🚨 If neither workflow argument nor `--workflows` option are provided,
+    will destroy **all** workflows defined in the deployment file.
+    
+    If option `--default-headers <TEXT>` or `-H <TEXT>` is provided, parses contents of <TEXT> as a JSON object and adds
+    the key-value pairs as additional headers for the API calls.<br/>
+    Examples:
+    ```
+    dbx destroy [OPTIONS] --default-headers '{"Some-Header-KeyWord": "Sample value", "Extra-Header": 42}'
+    dbx destroy [OPTIONS] -H '{"Some-Header-KeyWord": "Sample value", "Extra-Header": 42}'
+    ```""",
     name="destroy",
 )(destroy)
 

--- a/dbx/cli.py
+++ b/dbx/cli.py
@@ -136,8 +136,8 @@ app.command(
        appends it to the headers for the API calls.<br/>
        Examples:
        ```
-       dbx deploy [OPTIONS] --header name1=value1 --header name2=value2
-       dbx deploy [OPTIONS] -H name1=value1 -H name2=value2
+       dbx execute [OPTIONS] --header name1=value1 --header name2=value2
+       dbx execute [OPTIONS] -H name1=value1 -H name2=value2
        ```""",
 )(execute)
 
@@ -186,8 +186,8 @@ app.command(
     appends it to the headers for the API calls.<br/>
     Examples:
     ```
-    dbx deploy [OPTIONS] --header name1=value1 --header name2=value2
-    dbx deploy [OPTIONS] -H name1=value1 -H name2=value2
+    dbx launch [OPTIONS] --header name1=value1 --header name2=value2
+    dbx launch [OPTIONS] -H name1=value1 -H name2=value2
     ```""",
 )(launch)
 
@@ -207,8 +207,8 @@ app.command(
     appends it to the headers for the API calls.<br/>
     Examples:
     ```
-    dbx deploy [OPTIONS] --header name1=value1 --header name2=value2
-    dbx deploy [OPTIONS] -H name1=value1 -H name2=value2
+    dbx destroy [OPTIONS] --header name1=value1 --header name2=value2
+    dbx destroy [OPTIONS] -H name1=value1 -H name2=value2
     ```""",
     name="destroy",
 )(destroy)

--- a/dbx/commands/deploy.py
+++ b/dbx/commands/deploy.py
@@ -98,6 +98,8 @@ def deploy(
     dbx_echo(f"Starting new deployment for environment {environment_name}")
     if headers:
         headers: Dict[str, str] = parse_multiple(headers)
+    else:
+        headers = None
 
     api_client = prepare_environment(environment_name, headers)
     additional_tags = parse_multiple(tags)

--- a/dbx/commands/deploy.py
+++ b/dbx/commands/deploy.py
@@ -1,6 +1,6 @@
 import json
 from pathlib import Path
-from typing import List
+from typing import Dict, List, Any
 from typing import Optional
 
 import mlflow
@@ -43,12 +43,8 @@ def deploy(
         help="This option is deprecated, please use workflow name as argument instead.",
         show_default=False,
     ),
-    job_names: Optional[str] = typer.Option(
-        None, "--jobs", help="This option is deprecated, please use `--workflows` instead.", show_default=False
-    ),
-    workflow_names: Optional[str] = typer.Option(
-        None, "--workflows", help="Comma-separated list of workflow names to be deployed", show_default=False
-    ),
+    job_names: Optional[str] = typer.Option(None, "--jobs", help="This option is deprecated, please use `--workflows` instead.", show_default=False),
+    workflow_names: Optional[str] = typer.Option(None, "--workflows", help="Comma-separated list of workflow names to be deployed", show_default=False),
     requirements_file: Optional[Path] = REQUIREMENTS_FILE_OPTION,
     tags: Optional[List[str]] = TAGS_OPTION,
     environment_name: str = ENVIRONMENT_OPTION,
@@ -90,22 +86,32 @@ def deploy(
               Please note that output file will be overwritten if it exists.""",
         writable=True,
     ),
+    default_headers: Optional[str] = typer.Option(
+        None,
+        "--default-headers",
+        "-H",
+        help="""Supplies additional headers to API calls. Headers must be supplied in the form of a raw JSON string.
+
+        Helpful when calling the API from CI/CD pipelines that use a Service Principal to authenticate to Azure Databricks
+        and the Service Principal is not added to the Databricks Workspace.""",
+        writable=True,
+    ),
     branch_name: Optional[str] = BRANCH_NAME_OPTION,
     jinja_variables_file: Optional[Path] = JINJA_VARIABLES_FILE_OPTION,
     debug: Optional[bool] = DEBUG_OPTION,  # noqa
 ):
     dbx_echo(f"Starting new deployment for environment {environment_name}")
+    if default_headers:
+        default_headers = json.loads(default_headers)
 
-    api_client = prepare_environment(environment_name)
+    api_client = prepare_environment(environment_name, default_headers)
     additional_tags = parse_multiple(tags)
 
     if not branch_name:
         branch_name = get_current_branch_name()
 
     config_reader = ConfigReader(deployment_file, jinja_variables_file)
-    config = config_reader.with_build_properties(
-        BuildProperties(potential_build=True, no_rebuild=no_rebuild)
-    ).get_config()
+    config = config_reader.with_build_properties(BuildProperties(potential_build=True, no_rebuild=no_rebuild)).get_config()
 
     environment_info = config.get_environment(environment_name, raise_if_not_found=True)
 
@@ -123,9 +129,7 @@ def deploy(
     if _assets_only:
         any_pipelines = [w for w in deployable_workflows if w.workflow_type == WorkflowType.pipeline]
         if any_pipelines:
-            raise Exception(
-                f"Assets-only deployment mode is not supported for DLT pipelines: {[p.name for p in any_pipelines]}"
-            )
+            raise Exception(f"Assets-only deployment mode is not supported for DLT pipelines: {[p.name for p in any_pipelines]}")
 
     with mlflow.start_run() as deployment_run:
 

--- a/dbx/options.py
+++ b/dbx/options.py
@@ -153,3 +153,19 @@ LAUNCH_PARAMETERS_OPTION = typer.Option(
     show_default=True,
     callback=launch_parameters_callback,
 )
+
+HEADERS_OPTION = typer.Option(
+    None,
+    "--header",
+    "-H",
+    help="""Additional headers to API calls.
+
+
+    Example: `--header name1=value1`
+
+
+    Option might be repeated multiple times: `-H name1=value1 -H name2=value2`
+
+    Helpful when calling the API from CI/CD pipelines that use a Service Principal to authenticate to Azure Databricks
+    and the Service Principal is not added to the Databricks Workspace.""",
+)

--- a/dbx/utils/common.py
+++ b/dbx/utils/common.py
@@ -1,5 +1,5 @@
 import os
-from typing import Dict, List, Optional, Any
+from typing import Dict, List, Optional
 
 import git
 from databricks_cli.sdk.api_client import ApiClient
@@ -25,7 +25,7 @@ def transfer_profile_name(info: EnvironmentInfo):
         dbx_echo(f"Using profile provided via the env variable {ProfileEnvConfigProvider.DBX_PROFILE_ENV}")
 
 
-def prepare_environment(env_name: str, headers: Dict[str, Any] = None) -> ApiClient:
+def prepare_environment(env_name: str, headers: Optional[Dict[str, str]] = None) -> ApiClient:
     info = ProjectConfigurationManager().get(env_name)
     transfer_profile_name(info)
     MlflowStorageConfigurationManager.prepare(info)

--- a/dbx/utils/common.py
+++ b/dbx/utils/common.py
@@ -25,11 +25,11 @@ def transfer_profile_name(info: EnvironmentInfo):
         dbx_echo(f"Using profile provided via the env variable {ProfileEnvConfigProvider.DBX_PROFILE_ENV}")
 
 
-def prepare_environment(env_name: str, default_headers: Dict[str, Any] = None) -> ApiClient:
+def prepare_environment(env_name: str, headers: Dict[str, Any] = None) -> ApiClient:
     info = ProjectConfigurationManager().get(env_name)
     transfer_profile_name(info)
     MlflowStorageConfigurationManager.prepare(info)
-    return DatabricksClientProvider.get_v2_client(default_headers)
+    return DatabricksClientProvider.get_v2_client(headers)
 
 
 def generate_filter_string(env: str, branch_name: Optional[str]) -> str:

--- a/dbx/utils/common.py
+++ b/dbx/utils/common.py
@@ -1,5 +1,5 @@
 import os
-from typing import Dict, List, Optional
+from typing import Dict, List, Optional, Any
 
 import git
 from databricks_cli.sdk.api_client import ApiClient
@@ -25,11 +25,11 @@ def transfer_profile_name(info: EnvironmentInfo):
         dbx_echo(f"Using profile provided via the env variable {ProfileEnvConfigProvider.DBX_PROFILE_ENV}")
 
 
-def prepare_environment(env_name: str) -> ApiClient:
+def prepare_environment(env_name: str, default_headers: Dict[str, Any] = None) -> ApiClient:
     info = ProjectConfigurationManager().get(env_name)
     transfer_profile_name(info)
     MlflowStorageConfigurationManager.prepare(info)
-    return DatabricksClientProvider.get_v2_client()
+    return DatabricksClientProvider.get_v2_client(default_headers)
 
 
 def generate_filter_string(env: str, branch_name: Optional[str]) -> str:

--- a/tests/unit/api/test_auth.py
+++ b/tests/unit/api/test_auth.py
@@ -1,16 +1,15 @@
 from unittest.mock import MagicMock
 
 import pytest
-from databricks_cli.configure.provider import ProfileConfigProvider
 from pytest_mock import MockFixture
 
-from dbx.api.auth import AuthConfigProvider, DbxConfig, ProfileEnvConfigProvider
+from dbx.api.auth import AuthConfigProvider, DbxConfig, DbxProfileConfigProvider, ProfileEnvConfigProvider
 
 
 @pytest.fixture(name="_cleanup_auth_cache")
 def cleanup_auth_cache():
     method = AuthConfigProvider.get_config
-    method.__func__.cache_clear()
+    method.cache_clear()
 
 
 def test_auth_profile_non_existent(mocker: MockFixture, _cleanup_auth_cache):
@@ -25,13 +24,14 @@ def test_auth_profile_positive(mocker: MockFixture, _cleanup_auth_cache):
     mocker.patch.dict("os.environ", {ProfileEnvConfigProvider.DBX_PROFILE_ENV: profile_name}, clear=True)
     expected_config = DbxConfig(host="https://some-host", token="dbapiAAABBB", username=None, password=None)
     mocker.patch.object(
-        ProfileConfigProvider,
+        DbxProfileConfigProvider,
         "get_config",
         MagicMock(return_value=expected_config),
     )
     returned_config = AuthConfigProvider.get_config()
     assert expected_config.host == returned_config.host
     assert expected_config.token == returned_config.token
+    assert returned_config.headers == {}
 
 
 def test_auth_env_positive(mocker: MockFixture, _cleanup_auth_cache):
@@ -42,6 +42,7 @@ def test_auth_env_positive(mocker: MockFixture, _cleanup_auth_cache):
     returned_config = AuthConfigProvider.get_config()
     assert expected_config.host == returned_config.host
     assert expected_config.token == returned_config.token
+    assert returned_config.headers == {}
 
 
 def test_auth_both(mocker: MockFixture, _cleanup_auth_cache):
@@ -50,7 +51,7 @@ def test_auth_both(mocker: MockFixture, _cleanup_auth_cache):
     )
     profile_name = "test-existent-profile"
     mocker.patch.object(
-        ProfileConfigProvider,
+        DbxProfileConfigProvider,
         "get_config",
         MagicMock(
             return_value=DbxConfig(host="https://some-profile-host", token="dbapiAAABBB", username=None, password=None)
@@ -68,6 +69,7 @@ def test_auth_both(mocker: MockFixture, _cleanup_auth_cache):
     returned_config = AuthConfigProvider.get_config()
     assert expected_env_config.host == returned_config.host
     assert expected_env_config.token == returned_config.token
+    assert returned_config.headers == {}
 
 
 def test_auth_none(_cleanup_auth_cache):
@@ -75,9 +77,10 @@ def test_auth_none(_cleanup_auth_cache):
         AuthConfigProvider.get_config()
 
 
-def test_auth_env_aad_positive(mocker: MockFixture, _cleanup_auth_cache):
+@pytest.mark.usefixtures("_cleanup_auth_cache")
+def test_auth_env_aad_positive(mocker: MockFixture):
     expected_headers = {
-        "azure_ad_token": "eyJhbAAAABBBB",
+        "azure_sp_token": "eyJhbAAAABBBB",
         "workspace_id": (
             "/subscriptions/bc5bAAA-BBBB/resourceGroups/some-resource-group"
             "/providers/Microsoft.Databricks/workspaces/target-dtb-ws"
@@ -86,10 +89,10 @@ def test_auth_env_aad_positive(mocker: MockFixture, _cleanup_auth_cache):
     }
     expected_config = DbxConfig(
         host="https://some-other-host",
-        token="dbapiAAABBB",
         username=None,
         password=None,
-        azure_ad_token=expected_headers["azure_ad_token"],
+        token="dbapiAAABBB",
+        azure_sp_token=expected_headers["azure_sp_token"],
         workspace_id=expected_headers["workspace_id"],
         org_id=expected_headers["org_id"],
     )
@@ -98,12 +101,40 @@ def test_auth_env_aad_positive(mocker: MockFixture, _cleanup_auth_cache):
         {
             "DATABRICKS_HOST": expected_config.host,
             "DATABRICKS_TOKEN": expected_config.token,
-            "AAD_TOKEN": expected_headers["azure_ad_token"],
+            "AZURE_SERVICE_PRINCIPAL_TOKEN": expected_headers["azure_sp_token"],
             "WORKSPACE_ID": expected_headers["workspace_id"],
             "ORG_ID": expected_headers["org_id"],
         },
         clear=True,
     )
+    returned_config = AuthConfigProvider.get_config()
+    assert expected_config.host == returned_config.host
+    assert expected_config.token == returned_config.token
+    assert expected_config.headers == returned_config.headers
+
+
+@pytest.mark.usefixtures("_cleanup_auth_cache")
+def test_auth_profile_aad_positive(mocker: MockFixture):
+    profile_name = "test-existent-profile"
+    expected_config = DbxConfig(
+        host="https://some-profile-host",
+        username=None,
+        password=None,
+        token="dbapiAAABBB",
+        azure_sp_token="eyJhbAAAABBBB",
+        workspace_id=(
+            "/subscriptions/bc5bAAA-BBBB/resourceGroups/some-resource-group"
+            "/providers/Microsoft.Databricks/workspaces/target-dtb-ws"
+        ),
+        org_id="1928374655647382",
+    )
+    mocker.patch.dict("os.environ", {ProfileEnvConfigProvider.DBX_PROFILE_ENV: profile_name}, clear=True)
+    mocker.patch.object(
+        DbxProfileConfigProvider,
+        "get_config",
+        MagicMock(return_value=expected_config),
+    )
+
     returned_config = AuthConfigProvider.get_config()
     assert expected_config.host == returned_config.host
     assert expected_config.token == returned_config.token
@@ -119,7 +150,8 @@ def test_config_validity():
         AuthConfigProvider._verify_config_validity(bad_config)
 
 
-def test_resolution_order(mocker):
+@pytest.mark.usefixtures("_cleanup_auth_cache")
+def test_resolution_order(mocker: MockFixture):
     env_config = DbxConfig(host="https://some-env-based-host", token="dbapiAAABBB", username=None, password=None)
     mocker.patch.dict(
         "os.environ",

--- a/tests/unit/api/test_auth.py
+++ b/tests/unit/api/test_auth.py
@@ -1,29 +1,29 @@
 from unittest.mock import MagicMock
 
 import pytest
-from databricks_cli.configure.provider import ProfileConfigProvider, DatabricksConfig
+from databricks_cli.configure.provider import ProfileConfigProvider
 from pytest_mock import MockFixture
 
-from dbx.api.auth import AuthConfigProvider, ProfileEnvConfigProvider
+from dbx.api.auth import AuthConfigProvider, DbxConfig, ProfileEnvConfigProvider
 
 
-@pytest.fixture()
+@pytest.fixture(name="_cleanup_auth_cache")
 def cleanup_auth_cache():
     method = AuthConfigProvider.get_config
     method.__func__.cache_clear()
 
 
-def test_auth_profile_non_existent(mocker: MockFixture, cleanup_auth_cache):
+def test_auth_profile_non_existent(mocker: MockFixture, _cleanup_auth_cache):
     profile_name = "test-non-existent-profile"
     mocker.patch.dict("os.environ", {ProfileEnvConfigProvider.DBX_PROFILE_ENV: profile_name}, clear=True)
     with pytest.raises(Exception):
         AuthConfigProvider.get_config()
 
 
-def test_auth_profile_positive(mocker: MockFixture, cleanup_auth_cache):
+def test_auth_profile_positive(mocker: MockFixture, _cleanup_auth_cache):
     profile_name = "test-existent-profile"
     mocker.patch.dict("os.environ", {ProfileEnvConfigProvider.DBX_PROFILE_ENV: profile_name}, clear=True)
-    expected_config = DatabricksConfig(host="https://some-host", token="dbapiAAABBB", username=None, password=None)
+    expected_config = DbxConfig(host="https://some-host", token="dbapiAAABBB", username=None, password=None)
     mocker.patch.object(
         ProfileConfigProvider,
         "get_config",
@@ -34,10 +34,8 @@ def test_auth_profile_positive(mocker: MockFixture, cleanup_auth_cache):
     assert expected_config.token == returned_config.token
 
 
-def test_auth_env_positive(mocker: MockFixture, cleanup_auth_cache):
-    expected_config = DatabricksConfig(
-        host="https://some-other-host", token="dbapiAAABBB", username=None, password=None
-    )
+def test_auth_env_positive(mocker: MockFixture, _cleanup_auth_cache):
+    expected_config = DbxConfig(host="https://some-other-host", token="dbapiAAABBB", username=None, password=None)
     mocker.patch.dict(
         "os.environ", {"DATABRICKS_HOST": expected_config.host, "DATABRICKS_TOKEN": expected_config.token}, clear=True
     )
@@ -46,8 +44,8 @@ def test_auth_env_positive(mocker: MockFixture, cleanup_auth_cache):
     assert expected_config.token == returned_config.token
 
 
-def test_auth_both(mocker: MockFixture, cleanup_auth_cache):
-    expected_env_config = DatabricksConfig(
+def test_auth_both(mocker: MockFixture, _cleanup_auth_cache):
+    expected_env_config = DbxConfig(
         host="https://some-env-based-host", token="dbapiAAABBB", username=None, password=None
     )
     profile_name = "test-existent-profile"
@@ -55,9 +53,7 @@ def test_auth_both(mocker: MockFixture, cleanup_auth_cache):
         ProfileConfigProvider,
         "get_config",
         MagicMock(
-            return_value=DatabricksConfig(
-                host="https://some-profile-host", token="dbapiAAABBB", username=None, password=None
-            )
+            return_value=DbxConfig(host="https://some-profile-host", token="dbapiAAABBB", username=None, password=None)
         ),
     )
     mocker.patch.dict(
@@ -74,16 +70,49 @@ def test_auth_both(mocker: MockFixture, cleanup_auth_cache):
     assert expected_env_config.token == returned_config.token
 
 
-def test_auth_none(cleanup_auth_cache):
+def test_auth_none(_cleanup_auth_cache):
     with pytest.raises(Exception):
         AuthConfigProvider.get_config()
 
 
-def test_config_validity():
-    good_config = DatabricksConfig(host="https://some-host", token="dbapiAAABBB", username=None, password=None)
-    bad_config = DatabricksConfig(
-        host="https://some-host", username="some-username", password="some-password", token=None
+def test_auth_env_aad_positive(mocker: MockFixture, _cleanup_auth_cache):
+    expected_headers = {
+        "azure_ad_token": "eyJhbAAAABBBB",
+        "workspace_id": (
+            "/subscriptions/bc5bAAA-BBBB/resourceGroups/some-resource-group"
+            "/providers/Microsoft.Databricks/workspaces/target-dtb-ws"
+        ),
+        "org_id": "1928374655647382",
+    }
+    expected_config = DbxConfig(
+        host="https://some-other-host",
+        token="dbapiAAABBB",
+        username=None,
+        password=None,
+        azure_ad_token=expected_headers["azure_ad_token"],
+        workspace_id=expected_headers["workspace_id"],
+        org_id=expected_headers["org_id"],
     )
+    mocker.patch.dict(
+        "os.environ",
+        {
+            "DATABRICKS_HOST": expected_config.host,
+            "DATABRICKS_TOKEN": expected_config.token,
+            "AAD_TOKEN": expected_headers["azure_ad_token"],
+            "WORKSPACE_ID": expected_headers["workspace_id"],
+            "ORG_ID": expected_headers["org_id"],
+        },
+        clear=True,
+    )
+    returned_config = AuthConfigProvider.get_config()
+    assert expected_config.host == returned_config.host
+    assert expected_config.token == returned_config.token
+    assert expected_config.headers == returned_config.headers
+
+
+def test_config_validity():
+    good_config = DbxConfig(host="https://some-host", token="dbapiAAABBB", username=None, password=None)
+    bad_config = DbxConfig(host="https://some-host", username="some-username", password="some-password", token=None)
     AuthConfigProvider._verify_config_validity(good_config)
 
     with pytest.raises(Exception):
@@ -91,7 +120,7 @@ def test_config_validity():
 
 
 def test_resolution_order(mocker):
-    env_config = DatabricksConfig(host="https://some-env-based-host", token="dbapiAAABBB", username=None, password=None)
+    env_config = DbxConfig(host="https://some-env-based-host", token="dbapiAAABBB", username=None, password=None)
     mocker.patch.dict(
         "os.environ",
         {

--- a/tests/unit/api/test_client_provider.py
+++ b/tests/unit/api/test_client_provider.py
@@ -1,0 +1,81 @@
+import pytest
+from pytest_mock import MockFixture
+
+from databricks_cli.sdk import ApiClient
+from dbx.api.auth import AuthConfigProvider
+from dbx.api.client_provider import DatabricksClientProvider
+
+
+@pytest.fixture(name="_cleanup_auth_cache")
+def cleanup_auth_cache():
+    method = AuthConfigProvider.get_config
+    method.cache_clear()
+
+
+@pytest.mark.usefixtures("_cleanup_auth_cache")
+def test_get_v2_client_env_headers(mocker: MockFixture):
+    azure_sp_token = "eyJhbAAAABBBB"
+    workspace_id = (
+        "/subscriptions/bc5bAAA-BBBB/resourceGroups/some-resource-group"
+        "/providers/Microsoft.Databricks/workspaces/target-dtb-ws"
+    )
+    org_id = "1928374655647382"
+    expected_headers = {
+        "X-Databricks-Azure-SP-Management-Token": azure_sp_token,
+        "X-Databricks-Azure-Workspace-Resource-Id": workspace_id,
+        "X-Databricks-Org-Id": org_id,
+    }
+    host = "https://some-other-host"
+    token = "dbapiAAABBB"
+
+    expected_client = ApiClient(
+        host=host,
+        token=token,
+        default_headers=expected_headers,
+        command_name="cicdtemplates-",
+    )
+    mocker.patch.dict(
+        "os.environ",
+        {
+            "DATABRICKS_HOST": host,
+            "DATABRICKS_TOKEN": token,
+            "AZURE_SERVICE_PRINCIPAL_TOKEN": azure_sp_token,
+            "WORKSPACE_ID": workspace_id,
+            "ORG_ID": org_id,
+        },
+        clear=True,
+    )
+    returned_client = DatabricksClientProvider.get_v2_client()
+    assert returned_client.url == expected_client.url
+    assert returned_client.default_headers == expected_client.default_headers
+
+
+@pytest.mark.usefixtures("_cleanup_auth_cache")
+def test_get_v2_client_arg_headers(mocker: MockFixture):
+    expected_headers = {
+        "X-Databricks-Azure-SP-Management-Token": "eyJhbAAAABBBB",
+        "X-Databricks-Azure-Workspace-Resource-Id": (
+            "/subscriptions/bc5bAAA-BBBB/resourceGroups/some-resource-group"
+            "/providers/Microsoft.Databricks/workspaces/target-dtb-ws"
+        ),
+        "X-Databricks-Org-Id": "1928374655647382",
+    }
+    config = {
+        "host": "https://some-other-host",
+        "token": "dbapiAAABBB",
+        "default_headers": expected_headers,
+    }
+    expected_client = ApiClient(
+        host=config["host"],
+        token=config["token"],
+        default_headers=config["default_headers"],
+        command_name="cicdtemplates-",
+    )
+    mocker.patch.dict(
+        "os.environ",
+        {"DATABRICKS_HOST": config["host"], "DATABRICKS_TOKEN": config["token"]},
+        clear=True,
+    )
+    returned_client = DatabricksClientProvider.get_v2_client(headers=expected_headers)
+    assert returned_client.url == expected_client.url
+    assert returned_client.default_headers == expected_client.default_headers

--- a/tests/unit/commands/test_destroy.py
+++ b/tests/unit/commands/test_destroy.py
@@ -8,7 +8,7 @@ from pytest_mock import MockerFixture
 
 from dbx.api.config_reader import ConfigReader
 from dbx.api.destroyer import Destroyer
-from dbx.commands.destroy import ask_for_confirmation
+from dbx.commands.destroy import ask_for_confirmation, parse_multiple
 from dbx.models.cli.destroyer import DestroyerConfig, DeletionMode
 from tests.unit.conftest import invoke_cli_runner
 
@@ -76,3 +76,26 @@ def test_destroy_smoke_dry(mocker: MockerFixture, temp_project, monkeypatch, cap
     res = invoke_cli_runner("destroy --dry-run")
     launch_mock.assert_called_once()
     assert "Omitting the confirmation check" in res.stdout.replace("\n", "")
+
+
+@pytest.mark.usefixtures("temp_project")
+@pytest.mark.parametrize("h_option", ["-H", "--header"])
+def test_asset_eraser_additional_headers(h_option, mocker: MockerFixture, monkeypatch):
+    expected_headers = {
+        "azure_sp_token": "eyJhbAAAABBBB",
+        "workspace_id": (
+            "/subscriptions/bc5bAAA-BBBB/resourceGroups/some-resource-group"
+            "/providers/Microsoft.Databricks/workspaces/target-dtb-ws"
+        ),
+        "org_id": "1928374655647382",
+    }
+    env_mock = mocker.patch("dbx.commands.destroy.prepare_environment", MagicMock())
+    header_parse_mock = mocker.patch("dbx.commands.destroy.parse_multiple", wraps=parse_multiple)
+    launch_mock = mocker.patch.object(Destroyer, "launch", MagicMock())
+    kwargs = [f"{key}={val}" for key, val in expected_headers.items()]
+    cli_kwargs = " ".join([f"{h_option} {kw}" for kw in kwargs])
+    monkeypatch.setattr("builtins.input", lambda: "yes")
+    invoke_cli_runner(f"destroy {cli_kwargs}")
+    launch_mock.assert_called_once()
+    header_parse_mock.assert_called_once_with(kwargs)
+    env_mock.assert_called_once_with("default", expected_headers)

--- a/tests/unit/commands/test_execute.py
+++ b/tests/unit/commands/test_execute.py
@@ -325,7 +325,7 @@ def test_smoke_execute_additional_headers(mocker: MockerFixture, temp_project: P
     env_mock = mocker.patch("dbx.commands.execute.prepare_environment", MagicMock())
     header_parse_mock = mocker.patch("dbx.commands.execute.parse_multiple", wraps=parse_multiple)
     kwargs = [f"{key}={val}" for key, val in expected_headers.items()]
-    cli_kwargs = [f"--header {kw}" for kw in kwargs]
+    cli_kwargs = [arg for kw in kwargs for arg in ("--header", kw)]
     with patch(
         "dbx.api.client_provider.ApiV1Client.get_command_status",
         return_value={

--- a/tests/unit/commands/test_launch.py
+++ b/tests/unit/commands/test_launch.py
@@ -194,7 +194,7 @@ def test_launch_with_run_now_v21_params(mocker: MockFixture, temp_project: Path,
     client_mock = MagicMock()
     p = PropertyMock(return_value="2.1")
     type(client_mock).jobs_api_version = p
-    mocker.patch.object(DatabricksClientProvider, "get_v2_client", lambda: client_mock)
+    mocker.patch.object(DatabricksClientProvider, "get_v2_client", lambda x: client_mock)
     _chosen_job = deploy_and_get_job_name()
     prepare_job_service_mock(mocker, _chosen_job)
     launch_result = invoke_cli_runner(
@@ -206,7 +206,7 @@ def test_launch_with_run_now_v21_params(mocker: MockFixture, temp_project: Path,
 def test_launch_with_run_now_v20_params(mocker: MockFixture, temp_project: Path, mlflow_file_uploader, mock_storage_io):
     client_mock = MagicMock()
     type(client_mock).jobs_api_version = PropertyMock(return_value="2.0")
-    mocker.patch.object(DatabricksClientProvider, "get_v2_client", lambda: client_mock)
+    mocker.patch.object(DatabricksClientProvider, "get_v2_client", lambda x: client_mock)
     _chosen_job = deploy_and_get_job_name()
     prepare_job_service_mock(mocker, _chosen_job)
     launch_result = invoke_cli_runner(["launch", "--job", _chosen_job, "--parameters", '{"python_params":[1,2]}'])

--- a/tests/unit/commands/test_launch.py
+++ b/tests/unit/commands/test_launch.py
@@ -311,8 +311,8 @@ def test_smoke_launch_workflow_additional_headers(
     }
     header_parse_mock = mocker.patch("dbx.commands.launch.parse_multiple", wraps=parse_multiple)
     kwargs = [f"{key}={val}" for key, val in expected_headers.items()]
-    cli_kwargs = [f"--header {kw}" for kw in kwargs]
+    cli_kwargs = [arg for kw in kwargs for arg in ("--header", kw)]
 
     launch_job_result = invoke_cli_runner(["launch", _chosen_job, *cli_kwargs])
     assert launch_job_result.exit_code == 0
-    header_parse_mock.assert_called_once_with(kwargs)
+    header_parse_mock.assert_any_call(kwargs)


### PR DESCRIPTION
## Proposed changes

Closes https://github.com/databrickslabs/dbx/issues/467

## Types of changes

What types of changes does your code introduce to dbx?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Further comments

This PR adds three modes of supplying additional headers. The two main modes use either environment variables or additional config variables added to the databrickscfg file. through the following three environment variables:
| Environment variable | databrickscfg variable | Description |
|--|--|--|
| `AZURE_SERVICE_PRINCIPAL_TOKEN` | `azure_service_principal_token` | An Azure AD token generated on behalf of a Service Principal |
| `WORKSPACE_ID` | `workspace_id` | The Azure Resource ID of the target workspace |
| `ORG_ID` | `org_id` | The Databricks workspace ID of the target workspace |

By setting these variables, each `dbx` command execution will provide the following three headers to the `ApiClient` in addition to the predefined headers (i.e. `Authorization, Content-Type, User-Agent`):
- `X-Databricks-Azure-SP-Management-Token`
- `X-Databricks-Azure-Workspace-Resource-Id`
- `X-Databricks-Org-Id`

The addition of these additional headers will allow a Service Principal access to a Databricks workspace without being a registered user of said workspace (though it is still necessary for the SP to be at least a `Contributor` in the Azure Resource). This allows companies to improve the security around their automation without upgrading their Databricks subscription to the Premium tier.

As I mentioned, there are three modes of supplying additional headers. The last mode is through adding the `--header/-H key1=val1` option to the `dbx` commands. Like the `--tag` option for `dbx deploy`, this option can (and should) be repeated multiple times to add several headers.

I have not updated the documentation as I wouldn't know where to put this feature. I did update the CLI help messages to reflect the new options available for each of the commands.