### PR TITLE
Uses python:3.8-bullseye for GitLab CI stages.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 # Fixed
 
 - 🩹 Reload config after build in case if there are any dynamic components dependent on it
+- 🩹 Use `python:3.8-bullseye` docker image for Gitlab CI/CD in `python_basic` template
 - 🩹 Check if target repo exists before syncing and produce more clear error message if it does not.
 - 🩹 Type recognition of `named_parameters` in `python_wheel_task`
 - 🔨 Add support for extras for cloud file operations

--- a/dbx/templates/projects/python_basic/components/.gitlab-ci.yml
+++ b/dbx/templates/projects/python_basic/components/.gitlab-ci.yml
@@ -5,7 +5,7 @@ stages:
 
 unit-testing:
   stage: unit-testing
-  image: python:3.8-stretch
+  image: python:3.8-bullseye
   script:
     - echo "Install dependencies"
     - apt-get update
@@ -16,7 +16,7 @@ unit-testing:
 
 integration-testing:
   stage: integration-testing
-  image: python:3.7-stretch
+  image: python:3.8-bullseye
   script:
     - echo "Install dependencies"
     - pip install -e ".[local,test]"
@@ -27,7 +27,7 @@ integration-testing:
 
 release:
   stage: release
-  image: python:3.7-stretch
+  image: python:3.8-bullseye
   only:
     refs:
       - master


### PR DESCRIPTION
## Proposed changes

Closes #647 "python-3.8-stretch docker image does not exist in python_basic template with gitlab cicd."
by using `python:3.8-bullseye` docker image for all stages.

## Types of changes

What types of changes does your code introduce to dbx?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
