### PR TITLE
Ability to provide custom cicd and cloud components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [UNRELEASED] - YYYY-MM-DD
 
+## Added
+
+- 🔨 Add support for custom components (e.g. CI/CD templates) for `python_basic` templates
+
 # Fixed
 
 - 🩹 Reload config after build in case if there are any dynamic components dependent on it

--- a/dbx/templates/projects/python_basic/render/hooks/post_gen_project.py
+++ b/dbx/templates/projects/python_basic/render/hooks/post_gen_project.py
@@ -1,3 +1,4 @@
+import os
 import pathlib
 from typing import Callable, Dict, Optional, Any
 
@@ -7,8 +8,9 @@ from dbx.api.build import execute_shell_command
 from dbx.commands.configure import configure
 from dbx.constants import TEMPLATE_ROOT_PATH
 
+COMPONENTS_PATH = pathlib.Path("{{cookiecutter._template}}") / "components"
 DBX_TEMPLATE_NAME = "python_basic"
-COMPONENTS_PATH = TEMPLATE_ROOT_PATH / DBX_TEMPLATE_NAME / "components"
+DBX_COMPONENTS_PATH = TEMPLATE_ROOT_PATH / DBX_TEMPLATE_NAME / "components"
 
 CICD_TOOL = "{{cookiecutter.cicd_tool}}"
 CLOUD = "{{cookiecutter.cloud}}"
@@ -101,7 +103,10 @@ class PostProcessor:
             enable_context_based_upload_for_execute=False,
         )
 
-        env = Environment(loader=FileSystemLoader(COMPONENTS_PATH))
+        components_path = COMPONENTS_PATH
+        if not os.path.exists(components_path):
+            components_path = DBX_COMPONENTS_PATH
+        env = Environment(loader=FileSystemLoader(components_path))
 
         PostProcessor.process_ci_component(env)
         PostProcessor.process_cloud_component(env)

--- a/docs/guides/general/custom_templates.md
+++ b/docs/guides/general/custom_templates.md
@@ -10,6 +10,7 @@ If you would like to create a custom template, feel free to re-use the code you�
 - change the code in the `common.py`
 - change the project structure
 - choose another packaging tool, etc.
+- adapt CI/CD or cloud deployment components
 
 Pretty much anything you would like to add to your template could be configured using this functionality.
 
@@ -26,6 +27,18 @@ The following command:
 dbx init --path PATH [--checkout LOC]
 ```
 will check out a project template based on the [cookiecutter](https://cookiecutter.readthedocs.io/en/latest/index.html) approach from a git repository.
+
+This repository needs to follow this structure:
+```
+├── {{cookiecutter.project_name}} # cookiecutter project content
+├── hooks
+│   └── post_gen_project.py
+├── components                    # optional
+└── cookiecutter.json
+```
+
+It is possible to provide custom CI/CD and cloud deployment configs in a `components` folder in this repository. Otherwise the `dbx` provided [`components` folder](https://github.com/databrickslabs/dbx/tree/main/dbx/templates/projects/python_basic/components) is used.
+
 
 The `--checkout` flag is optional. If provided, `dbx` will check out a branch, tag or commit after cloning the repo. Default behaviour is to check out the `master` or `main` branch.
 


### PR DESCRIPTION
## Proposed changes

As a devops developer I need to provide custom CI/CD configs with certain adaptions for our infrastructure. As far as I understood, this is currently not possible as only the `dbx` provided `components` folder is used.

Thus, this PR
- documents custom git template structure
- adds ability to provide custom CI/CD and cloud configs in a `components` folder of the cookiecutter git repository

## For discussion

To be compatible with the upstream `cookiecutter` philosophy I would furthermore suggest to

### Either
Change the folder structure of the templates. I see the `components` folder a subfolder of the specific template( e.g. `dbx/templates/projects/python_basic/render/components`) as all the required variables and code dependencies for these "components" are defined in `cookiecutter.json` and `post_gen_project.py`. There is no clear separation, thus a change in `components` does not make any sense if you do not adapt the `python_basic` template.

### Or
Provide all "components" directly in the cookiecutter `render` template and only remove unused CI/CD files as suggested [by the cookiecutter docs](https://cookiecutter.readthedocs.io/en/stable/advanced/hooks.html#example-conditional-files-directories). In this case, the various values for `node_type_id` in `conf/deployment.yaml` could be rendered with [choice variables](https://cookiecutter.readthedocs.io/en/stable/advanced/choice_variables.html). 


This is however not yet implemented here - I can provide the code if desired.

## Types of changes

What types of changes does your code introduce to dbx?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation Update (if none of the other choices apply)

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
