### PR TITLE
Fix nested experiment logic within launch command

### DIFF
--- a/dbx/commands/launch.py
+++ b/dbx/commands/launch.py
@@ -166,30 +166,30 @@ def launch(
             else:
                 dbx_echo("DLT pipeline launched successfully")
 
-        if trace:
-            if isinstance(process_info, RunData):
-                status = trace_workflow_object(api_client, process_info, include_output, kill_on_sigterm)
-                additional_tags = {
-                    "job_id": object_id,
-                    "run_id": process_info.run_id,
-                }
-            else:
-                final_state = PipelineTracer.start(
-                    api_client=api_client, process_info=process_info, pipeline_id=object_id
-                )
-                if final_state == PipelineUpdateState.FAILED:
-                    raise Exception(
-                        f"Tracked pipeline {object_id} failed during execution, please check the UI for details."
+            if trace:
+                if isinstance(process_info, RunData):
+                    status = trace_workflow_object(api_client, process_info, include_output, kill_on_sigterm)
+                    additional_tags = {
+                        "job_id": object_id,
+                        "run_id": process_info.run_id,
+                    }
+                else:
+                    final_state = PipelineTracer.start(
+                        api_client=api_client, process_info=process_info, pipeline_id=object_id
                     )
-                status = final_state
-                additional_tags = {"pipeline_id": object_id}
-        else:
-            status = "NOT_TRACKED"
-            dbx_echo(
-                "Workflow successfully launched in the non-tracking mode 🚀. "
-                "Please check Databricks UI for job status 👀"
-            )
-        log_launch_info(additional_tags, status, environment_name, branch_name)
+                    if final_state == PipelineUpdateState.FAILED:
+                        raise Exception(
+                            f"Tracked pipeline {object_id} failed during execution, please check the UI for details."
+                        )
+                    status = final_state
+                    additional_tags = {"pipeline_id": object_id}
+            else:
+                status = "NOT_TRACKED"
+                dbx_echo(
+                    "Workflow successfully launched in the non-tracking mode 🚀. "
+                    "Please check Databricks UI for job status 👀"
+                )
+            log_launch_info(additional_tags, status, environment_name, branch_name)
 
 
 def trace_workflow_object(


### PR DESCRIPTION
## Proposed changes

With the upgrade of dbx to version v.0.8.x, the trace logic / update logic of experiment is not within the nested experiment anymore. This causes issues for us, since the parent experiment `dbx_action_type` is updated from `deploy` to `launch` and upcoming launches do not find the respective MLFlow experiment anymore. Looking at the [v0.7.6 version](https://github.com/databrickslabs/dbx/blob/v0.7.6/dbx/commands/launch.py#L144) of dbx, the logic for tracing and updating was inside the nested experiment. Therefore, I consider this a bug.

## Types of changes

What types of changes does your code introduce to dbx?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Further comments

NA
