### PR TITLE
🩹 fix build with no-package behaviour

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [Please read through the Keep a Changelog (~5min)](https://keepachangelog.com/en/1.0.0/).
 ## [UNRELEASED] - YYYY-MM-DD
 
+# Fixed
+
+- 🔨 fix `dbx deploy --no-package` when `--no-rebuild` is not specified
+
 ## [0.8.8] - 2022-02-22
 
 # Fixed

--- a/dbx/commands/deploy.py
+++ b/dbx/commands/deploy.py
@@ -103,6 +103,7 @@ def deploy(
 
     api_client = prepare_environment(environment_name, headers)
     additional_tags = parse_multiple(tags)
+    no_rebuild = no_rebuild or no_package
 
     if not branch_name:
         branch_name = get_current_branch_name()

--- a/tests/unit/commands/test_deploy.py
+++ b/tests/unit/commands/test_deploy.py
@@ -263,8 +263,15 @@ def test_deploy_empty_workflows_list(temp_project, mlflow_file_uploader, mock_st
 
 
 @patch(f"{deploy.__name__}.CorePackageManager")
+@patch(f"{deploy.__name__}.BuildProperties")
 def test_deploy_with_no_package(
-    mock_core_package_manager, mlflow_file_uploader, mocker, mock_storage_io, mock_api_v2_client, temp_project
+    mock_build_properties,
+    mock_core_package_manager,
+    mlflow_file_uploader,
+    mocker,
+    mock_storage_io,
+    mock_api_v2_client,
+    temp_project,
 ):
     mocker.patch.object(NamedJobsService, "create", MagicMock(return_value=1))
     result_file = ".dbx/deployment-result.json"
@@ -273,6 +280,7 @@ def test_deploy_with_no_package(
         ["deploy", "--environment", "default", "--no-package", "--write-specs-to-file", result_file],
     )
     assert deploy_result.exit_code == 0
+    mock_build_properties.assert_called_once_with(potential_build=True, no_rebuild=True)
     mock_core_package_manager.assert_not_called()
     _content = JsonUtils.read(Path(result_file))
     assert not any([t["libraries"] for w in _content["default"]["workflows"] for t in w["tasks"]])


### PR DESCRIPTION
## Proposed changes

Previous PR https://github.com/databrickslabs/dbx/pull/623 was based on v0.8.7, but it is found that there was [a change](https://github.com/databrickslabs/dbx/pull/581/files#diff-c108d519adff439da3775acce0b0dab67b5ef888e760fe4b685dd47ebd03e28b) in v0.8.8 which is in confliction with https://github.com/databrickslabs/dbx/pull/623, as it introduced `--no-rebuild` logic in `def get_config(self)`. I raised this PR to patch this.

## Types of changes

What types of changes does your code introduce to dbx?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
