### PR TITLE
Add `dbx sync workspace` subcommand

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 [Please read through the Keep a Changelog (~5min)](https://keepachangelog.com/en/1.0.0/).
 
+### Added
+
+- Add `sync workspace` subcommand for syncing local files to Databricks and watching for changes.
 
 ## [0.8.10] - 2023-03-21
 

--- a/dbx/commands/sync/sync.py
+++ b/dbx/commands/sync/sync.py
@@ -367,7 +367,9 @@ def workspace(
             This is optional, as the user name is determined automatically using the scim/me API.
 
             If it cannot be determined, or to use a different user for the path,
-            the user name may be specified using this option.""",
+            the user name may be specified using this option.
+            
+            If an absolute path is passed to the dest_dir argument, this is ignored.""",
     ),
     source: Optional[str] = SOURCE_OPTION,
     full_sync: bool = FULL_SYNC_OPTION,
@@ -378,10 +380,12 @@ def workspace(
         ...,
         "--dest-dir",
         "-d",
-        help="""The name of the Databricks Workspace directory to sync to.
+        help="""The name of the Databricks Workspace directory to sync to. By default, user directories are used.
 
             User directories exist in the Databricks Workspace under a path of the form `/Users/<user>/<dir>`.
             This specifies the `<dir>` portion of the path.
+            
+            If an absolute path is passed, it will be used as is.
             
             If the directory does not exist, it and its parent directories will be created.""",
     ),

--- a/dbx/commands/sync/sync.py
+++ b/dbx/commands/sync/sync.py
@@ -32,7 +32,7 @@ from dbx.commands.sync.options import (
 )
 from dbx.options import PROFILE_OPTION
 from dbx.sync import DeleteUnmatchedOption
-from dbx.sync.clients import DBFSClient, ReposClient
+from dbx.sync.clients import DBFSClient, ReposClient, WorkspaceClient
 from dbx.sync.config import get_databricks_config
 from dbx.utils import dbx_echo
 
@@ -330,6 +330,107 @@ def repo(
             "clicking 'Add Repo', unchecking the 'Create repo by cloning a Git repository' option, and providing "
             f"{dest_repo} as the repository name."
         )
+
+    main_loop(
+        source=source,
+        matcher=matcher,
+        client=client,
+        full_sync=full_sync,
+        dry_run=dry_run,
+        watch=watch,
+        polling_interval_secs=polling_interval_secs,
+        delete_unmatched_option=delete_unmatched_option,
+    )
+
+
+# TODO: Limit redundancies with repo command
+# TODO: Add tests
+
+@sync_app.command(
+    short_help="""
+    🔀 Syncs from a source directory to a Databricks Workspace directory
+    """,
+    help="""
+    🔀 Syncs from a source directory to a Databricks Workspace directory
+    """,
+)
+def workspace(
+    user_name: Optional[str] = typer.Option(
+        None,
+        "--user",
+        "-u",
+        help="""The user who owns the Workspace directory to sync to.
+
+            User directories exist in the Databricks Workspace under a path of the form `/Users/<user>/<dir>`.
+            This specifies the `<user>` portion of the path.
+
+            This is optional, as the user name is determined automatically using the scim/me API.
+
+            If it cannot be determined, or to use a different user for the path,
+            the user name may be specified using this option.""",
+    ),
+    source: Optional[str] = SOURCE_OPTION,
+    full_sync: bool = FULL_SYNC_OPTION,
+    dry_run: bool = DRY_RUN_OPTION,
+    include_dirs: Optional[List[str]] = INCLUDE_DIRS_OPTION,
+    force_include_dirs: Optional[List[str]] = FORCE_INCLUDE_DIRS_OPTION,
+    dest_dir: str = typer.Option(
+        ...,
+        "--dest-dir",
+        "-d",
+        help="""The name of the Databricks Workspace directory to sync to.
+
+            User directories exist in the Databricks Workspace under a path of the form `/Users/<user>/<dir>`.
+            This specifies the `<dir>` portion of the path.
+            
+            If the directory does not exist, it and its parent directories will be created.""",
+    ),
+    exclude_dirs: Optional[List[str]] = EXCLUDE_DIRS_OPTION,
+    profile: str = PROFILE_OPTION,
+    environment: str = SYNC_ENVIRONMENT_OPTION,
+    watch: bool = WATCH_OPTION,
+    polling_interval_secs: Optional[float] = POLLING_INTERVAL_OPTION,
+    include_patterns: Optional[List[str]] = INCLUDE_PATTERNS_OPTION,
+    force_include_patterns: Optional[List[str]] = FORCE_INCLUDE_PATTERNS_OPTION,
+    exclude_patterns: Optional[List[str]] = EXCLUDE_PATTERNS_OPTION,
+    use_gitignore: bool = USE_GITIGNORE_OPTION,
+    delete_unmatched_option: DeleteUnmatchedOption = UNMATCHED_BEHAVIOUR_OPTION,
+):
+    # watch defaults to true, so to make it easy to just add --dry-run without having to add --no-watch,
+    # we'll set watch to false here.
+    if dry_run:
+        watch = False
+
+    if environment:
+        dbx_echo("Environment option is provided, therefore environment-based config will be used")
+        _info = ProjectConfigurationManager().get(environment)
+        config = ProfileConfigProvider(_info.profile).get_config()
+    else:
+        config = get_databricks_config(profile)
+
+    if not user_name:
+        user_name = get_user_name(config)
+
+    if not user_name:
+        raise click.UsageError(
+            "Destination repo path can't be automatically determined because the user is not known. "
+            "Please either specify the user with --user."
+        )
+
+    source = handle_source(source)
+
+    matcher = create_path_matcher(
+        source=source,
+        include_dirs=include_dirs,
+        exclude_dirs=exclude_dirs,
+        include_patterns=include_patterns,
+        exclude_patterns=exclude_patterns,
+        use_gitignore=use_gitignore,
+        force_include_dirs=force_include_dirs,
+        force_include_patterns=force_include_patterns,
+    )
+
+    client = WorkspaceClient(user=user_name, dir_name=dest_dir, config=config)
 
     main_loop(
         source=source,

--- a/dbx/sync/clients.py
+++ b/dbx/sync/clients.py
@@ -1,5 +1,6 @@
 import asyncio
 import base64
+import os
 from abc import ABC, abstractmethod
 
 import aiohttp
@@ -344,7 +345,10 @@ class WorkspaceClient(BaseClient):
             raise ValueError("Expected a user")
         if not dir_name:
             raise ValueError("dir_name is required")
-        self.base_path = f"/Users/{user}/{dir_name}"
+        if os.path.isabs(dir_name):
+            self.base_path = dir_name
+        else:
+            self.base_path = f"/Users/{user}/{dir_name}"
         self.api_token = config.token
         self.host = strip_databricks_url(config.host)
         self.workspace_api_base_path = f"{self.host}/api/2.0/workspace"

--- a/dbx/sync/clients.py
+++ b/dbx/sync/clients.py
@@ -243,15 +243,10 @@ class DBFSClient(BaseClient):
             )
 
 
-class ReposClient(BaseClient):
-    name = "repos"
-
-    def __init__(self, *, user: str, repo_name: str, config: DatabricksConfig):
+class AbstractWorkspaceClient(BaseClient):
+    def __init__(self, *, user: str, config: DatabricksConfig):
         if not user:
             raise ValueError("Expected a user")
-        if not repo_name:
-            raise ValueError("repo_name is required")
-        self.base_path = f"/Repos/{user}/{repo_name}"
         self.api_token = config.token
         self.host = strip_databricks_url(config.host)
         self.workspace_api_base_path = f"{self.host}/api/2.0/workspace"
@@ -273,6 +268,50 @@ class ReposClient(BaseClient):
             api_token=self.api_token,
             ssl=self.ssl,
         )
+
+    async def mkdirs(self, sub_path: str, *, session: aiohttp.ClientSession):
+        check_path(sub_path)
+        path = f"{self.base_path}/{sub_path}"
+        await self._api_mkdirs(
+            api_base_path=self.workspace_api_base_path,
+            path=path,
+            session=session,
+            api_token=self.api_token,
+            ssl=self.ssl,
+        )
+
+    async def put(self, sub_path: str, full_source_path: str, *, session: aiohttp.ClientSession):
+        check_path(sub_path)
+        path = f"{self.base_path}/{sub_path}"
+        dbx_echo(f"Putting {path}")
+        with open(full_source_path, "rb") as f:
+            content = f.read()
+            path = path.lstrip("/")
+            url = f"{self.workspace_files_api_base_path}/{path}"
+            params = {"overwrite": "true"}
+            while True:
+                headers = get_headers(self.api_token, self.name)
+                more_opts = {"ssl": self.ssl} if self.ssl is not None else {}
+                async with session.post(url=url, data=content, params=params, headers=headers, **more_opts) as resp:
+                    if resp.status == 200:
+                        break
+                    if resp.status == 429:
+                        dbx_echo("Rate limited")
+                        await _rate_limit_sleep(resp)
+                    else:
+                        txt = await resp.text()
+                        dbx_echo(f"HTTP {resp.status}: {txt}")
+                        raise ClientError(resp.status)
+
+
+class ReposClient(AbstractWorkspaceClient):
+    name = "repos"
+
+    def __init__(self, *, user: str, repo_name: str, config: DatabricksConfig):
+        if not repo_name:
+            raise ValueError("repo_name is required")
+        self.base_path = f"/Repos/{user}/{repo_name}"
+        super().__init__(user=user, config=config)
 
     async def exists(self, *, session: aiohttp.ClientSession) -> bool:
         """Checks if the target repo the client will sync to exists.
@@ -299,108 +338,15 @@ class ReposClient(BaseClient):
                 dbx_echo(f"HTTP {resp.status}: {txt}")
                 raise ClientError(resp.status)
 
-    async def mkdirs(self, sub_path: str, *, session: aiohttp.ClientSession):
-        check_path(sub_path)
-        path = f"{self.base_path}/{sub_path}"
-        await self._api_mkdirs(
-            api_base_path=self.workspace_api_base_path,
-            path=path,
-            session=session,
-            api_token=self.api_token,
-            ssl=self.ssl,
-        )
 
-    async def put(self, sub_path: str, full_source_path: str, *, session: aiohttp.ClientSession):
-        check_path(sub_path)
-        path = f"{self.base_path}/{sub_path}"
-        dbx_echo(f"Putting {path}")
-        with open(full_source_path, "rb") as f:
-            content = f.read()
-            path = path.lstrip("/")
-            url = f"{self.workspace_files_api_base_path}/{path}"
-            params = {"overwrite": "true"}
-            while True:
-                headers = get_headers(self.api_token, self.name)
-                more_opts = {"ssl": self.ssl} if self.ssl is not None else {}
-                async with session.post(url=url, data=content, params=params, headers=headers, **more_opts) as resp:
-                    if resp.status == 200:
-                        break
-                    if resp.status == 429:
-                        dbx_echo("Rate limited")
-                        await _rate_limit_sleep(resp)
-                    else:
-                        txt = await resp.text()
-                        dbx_echo(f"HTTP {resp.status}: {txt}")
-                        raise ClientError(resp.status)
-                    
-
-# TODO: Limit redundancies with RepoClient
-# TODO: Add tests
-
-class WorkspaceClient(BaseClient):
+class WorkspaceClient(AbstractWorkspaceClient):
     name = "workspace"
 
     def __init__(self, *, user: str, dir_name: str, config: DatabricksConfig):
-        if not user:
-            raise ValueError("Expected a user")
         if not dir_name:
             raise ValueError("dir_name is required")
         if os.path.isabs(dir_name):
             self.base_path = dir_name
         else:
             self.base_path = f"/Users/{user}/{dir_name}"
-        self.api_token = config.token
-        self.host = strip_databricks_url(config.host)
-        self.workspace_api_base_path = f"{self.host}/api/2.0/workspace"
-        self.workspace_files_api_base_path = f"{self.host}/api/2.0/workspace-files/import-file"
-        if config.insecure is None:
-            self.ssl = None
-        else:
-            self.ssl = not config.insecure
-        dbx_echo(f"Target base path: {self.base_path}")
-
-    async def delete(self, sub_path: str, *, session: aiohttp.ClientSession, recursive: bool = False):
-        check_path(sub_path)
-        path = f"{self.base_path}/{sub_path}"
-        await self._api_delete(
-            api_base_path=self.workspace_api_base_path,
-            path=path,
-            session=session,
-            recursive=recursive,
-            api_token=self.api_token,
-            ssl=self.ssl,
-        )
-
-    async def mkdirs(self, sub_path: str, *, session: aiohttp.ClientSession):
-        check_path(sub_path)
-        path = f"{self.base_path}/{sub_path}"
-        await self._api_mkdirs(
-            api_base_path=self.workspace_api_base_path,
-            path=path,
-            session=session,
-            api_token=self.api_token,
-            ssl=self.ssl,
-        )
-
-    async def put(self, sub_path: str, full_source_path: str, *, session: aiohttp.ClientSession):
-        check_path(sub_path)
-        path = f"{self.base_path}/{sub_path}"
-        dbx_echo(f"Putting {path}")
-        with open(full_source_path, "rb") as f:
-            content = f.read()
-            path = path.lstrip("/")
-            url = f"{self.workspace_files_api_base_path}/{path}"
-            params = {"overwrite": "true"}
-            while True:
-                headers = get_headers(self.api_token, self.name)
-                more_opts = {"ssl": self.ssl} if self.ssl is not None else {}
-                async with session.post(url=url, data=content, params=params, headers=headers, **more_opts) as resp:
-                    if resp.status == 200:
-                        break
-                    if resp.status == 429:
-                        dbx_echo("Rate limited")
-                        await _rate_limit_sleep(resp)
-                    else:
-                        txt = await resp.text()
-                        dbx_echo(f"HTTP {resp.status}: {txt}")
-                        raise ClientError(resp.status)
+        super().__init__(user=user, config=config)


### PR DESCRIPTION
## Proposed changes

Adding support for syncing from local to an arbitrary Databricks Workspace location (i.e., `dbx sync workspace`). This could help enable more IDE development for those developing in workspaces where Repos are disabled (but Files in Workspace are not).

## Types of changes

What types of changes does your code introduce to dbx?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Further comments

This largely borrows from the same methods behind `dbx sync repo`. The two main exceptions are:
1. It allows for relative (i.e., `/Users/<user>/<dest>`) or absolute destination paths.
2. It does not require a destination path to manually be created before syncing.

In the documentation (aside from the CLI reference), I haven't added anything to specifically call this subcommand out. This is because Databricks Repos are strongly preferred when available.

It's worth calling out one behavioral pattern that I stumbled across, which may require some refactor on my part:
1. When `dbx sync workspace` is run and the repo is successfully synced;
2. then, the destination directory is manually (or programmatically) deleted from within the workspace;
3. running `dbx sync workspace` a second time yields a 404 because parent directories aren't automatically recreated (I'm assuming that's got something to do with the artifacts from prior syncs retained locally in `.dbx/sync`).