### PR TITLE
Enable Jinja2 templates from working dir

### DIFF
--- a/dbx/api/config_reader.py
+++ b/dbx/api/config_reader.py
@@ -72,7 +72,7 @@ class Jinja2ConfigReader(_AbstractConfigReader):
     def _render_content(cls, file_path: Path, _var: Dict[str, Any], _wd: bool) -> str:
         if _wd:
             working_dir = os.path.abspath(os.curdir)
-            file_name = file_path.relative_to(working_dir)
+            file_name = str(file_path.relative_to(working_dir))
         else:
             working_dir = file_path.absolute().parent
             file_name = file_path.name

--- a/dbx/api/config_reader.py
+++ b/dbx/api/config_reader.py
@@ -79,9 +79,6 @@ class Jinja2ConfigReader(_AbstractConfigReader):
         
         dbx_echo(f"The following path will be used for the jinja loader: {working_dir} with file {file_name}")
 
-        working_dir = os.path.abspath(os.curdir)
-        dbx_echo(f"The working dir {working_dir} will be added to jinja loader.")
-
         env = jinja2.Environment(loader=jinja2.FileSystemLoader(working_dir))
         template = env.get_template(file_name)
         template.globals["dbx"] = dbx_jinja

--- a/dbx/commands/deploy.py
+++ b/dbx/commands/deploy.py
@@ -18,6 +18,7 @@ from dbx.options import (
     DEPLOYMENT_FILE_OPTION,
     ENVIRONMENT_OPTION,
     HEADERS_OPTION,
+    JINJA_TEMPLATES_WORKING_DIR,
     JINJA_VARIABLES_FILE_OPTION,
     NO_PACKAGE_OPTION,
     NO_REBUILD_OPTION,
@@ -88,6 +89,7 @@ def deploy(
     ),
     headers: Optional[List[str]] = HEADERS_OPTION,
     branch_name: Optional[str] = BRANCH_NAME_OPTION,
+    jinja_working_directory: Optional[bool] = JINJA_TEMPLATES_WORKING_DIR,
     jinja_variables_file: Optional[Path] = JINJA_VARIABLES_FILE_OPTION,
     debug: Optional[bool] = DEBUG_OPTION,  # noqa
 ):
@@ -104,7 +106,7 @@ def deploy(
     if not branch_name:
         branch_name = get_current_branch_name()
 
-    config_reader = ConfigReader(deployment_file, jinja_variables_file)
+    config_reader = ConfigReader(deployment_file, jinja_variables_file, jinja_working_directory)
     config = config_reader.with_build_properties(
         BuildProperties(potential_build=True, no_rebuild=no_rebuild)
     ).get_config()

--- a/dbx/commands/destroy.py
+++ b/dbx/commands/destroy.py
@@ -14,6 +14,7 @@ from dbx.options import (
     DEPLOYMENT_FILE_OPTION,
     ENVIRONMENT_OPTION,
     HEADERS_OPTION,
+    JINJA_TEMPLATES_WORKING_DIR,
     JINJA_VARIABLES_FILE_OPTION,
     WORKFLOW_ARGUMENT,
 )
@@ -28,6 +29,7 @@ def destroy(
     ),
     deployment_file: Optional[Path] = DEPLOYMENT_FILE_OPTION,
     environment_name: str = ENVIRONMENT_OPTION,
+    jinja_working_directory: Optional[bool] = JINJA_TEMPLATES_WORKING_DIR,
     jinja_variables_file: Optional[Path] = JINJA_VARIABLES_FILE_OPTION,
     deletion_mode: DeletionMode = typer.Option(
         DeletionMode.all,
@@ -60,7 +62,7 @@ def destroy(
 
     workflow_names = workflow_names.split(",") if workflow_names else []
 
-    global_config = ConfigReader(deployment_file, jinja_variables_file).get_config()
+    global_config = ConfigReader(deployment_file, jinja_variables_file, jinja_working_directory).get_config()
     env_config = global_config.get_environment(environment_name, raise_if_not_found=True)
     relevant_workflows = env_config.payload.select_relevant_or_all_workflows(workflow_name, workflow_names)
 

--- a/dbx/commands/execute.py
+++ b/dbx/commands/execute.py
@@ -17,6 +17,7 @@ from dbx.options import (
     ENVIRONMENT_OPTION,
     EXECUTE_PARAMETERS_OPTION,
     HEADERS_OPTION,
+    JINJA_TEMPLATES_WORKING_DIR,
     JINJA_VARIABLES_FILE_OPTION,
     NO_PACKAGE_OPTION,
     NO_REBUILD_OPTION,
@@ -66,6 +67,7 @@ def execute(
         Useful when core package has extras section and installation of these extras is required.""",
     ),
     headers: Optional[List[str]] = HEADERS_OPTION,
+    jinja_working_directory: Optional[bool] = JINJA_TEMPLATES_WORKING_DIR,
     jinja_variables_file: Optional[Path] = JINJA_VARIABLES_FILE_OPTION,
     parameters: Optional[str] = EXECUTE_PARAMETERS_OPTION,
     debug: Optional[bool] = DEBUG_OPTION,  # noqa
@@ -86,7 +88,7 @@ def execute(
         f"on cluster {cluster_name} (id: {cluster_id})"
     )
 
-    config_reader = ConfigReader(deployment_file, jinja_variables_file)
+    config_reader = ConfigReader(deployment_file, jinja_variables_file, jinja_working_directory)
 
     config = config_reader.with_build_properties(
         BuildProperties(potential_build=True, no_rebuild=no_rebuild)

--- a/dbx/options.py
+++ b/dbx/options.py
@@ -43,6 +43,15 @@ DEPLOYMENT_FILE_OPTION = typer.Option(
     show_default=False,
 )
 
+JINJA_TEMPLATES_WORKING_DIR = typer.Option(
+    False,
+    "--jinja-working-dir",
+    is_flag=True,
+    help="""Use working directory as base path for Jinja Template discovery.
+
+    If not provided, default behavior is to use the deployment file parent directory.""",
+)
+
 JINJA_VARIABLES_FILE_OPTION = typer.Option(
     None,
     "--jinja-variables-file",

--- a/tests/deployment-configs/nested-configs/09-jinja-include.json.j2
+++ b/tests/deployment-configs/nested-configs/09-jinja-include.json.j2
@@ -1,14 +1,19 @@
 {
     "default": {
-        "jobs": [
+        "workflows": [
             {
                 "name": "your-job-name",
-                "new_cluster": {% include 'includes/cluster-test.json.j2' %},
-                "libraries": [],
-                "max_retries": 0,
-                "spark_python_task": {
-                    "python_file": "file://placeholder_1.py"
-                }
+                "tasks": [
+                    {
+                        "name": "main",
+                        "new_cluster": {% include 'conf/includes/cluster-test.json.j2' %},
+                        "max_retries": 0,
+                        "notebook_task": {
+                            "notebook_path": "/Repos/some/notebook"
+                        }
+                    }
+                ],
+                "workflow_type": "pipeline"
             }
         ]
     }

--- a/tests/unit/commands/test_deploy.py
+++ b/tests/unit/commands/test_deploy.py
@@ -6,6 +6,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 import yaml
 from pytest_mock import MockerFixture
+from jinja2.exceptions import TemplateNotFound
 
 from dbx.api.config_reader import ConfigReader
 from dbx.api.configure import EnvironmentInfo, ProjectConfigurationManager
@@ -326,6 +327,11 @@ def test_jinja_working_dir(mlflow_file_uploader, mock_storage_io, mock_api_v2_cl
     includes_dir.mkdir()
     shutil.copy(src_deployment_file, dst_deployment_file)
     shutil.copy(src_include_file, dst_include_file)
+
+    with pytest.raises(TemplateNotFound):
+        deploy_result = invoke_cli_runner(
+            ["deploy", f"--deployment-file", str(dst_deployment_file)]
+        )
 
     deploy_result = invoke_cli_runner(
         ["deploy", f"--deployment-file", str(dst_deployment_file), "--jinja-working-dir"]


### PR DESCRIPTION
## Proposed changes

Enable users to (optionally) set the Jinja2 base working directory to `os.curdir`. By using the new option `--jinja-working-dir`, Jinja will treat the current directory as a working directory and Templates can be loaded from any namespace downstream.

This was the default behavior in version `0.6.0` but was removed at some point. Issue: https://github.com/databrickslabs/dbx/issues/844

## Types of changes

What types of changes does your code introduce to dbx?

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
