### PR TITLE
Make a cron expression in documentation a valid quartz expression

### DIFF
--- a/docs/reference/deployment.md
+++ b/docs/reference/deployment.md
@@ -198,7 +198,7 @@ environments:
     workflows:
       - name: "workflow1"
         schedule:
-         quartz_cron_expression: "0 0 * * *" #(1)
+         quartz_cron_expression: "0 0 0 ? * * *" #(1)
          timezone_id: "Europe/Berlin" #(2)
 ```
 


### PR DESCRIPTION
## Proposed changes

Small fix doc fix for a minor issue I noticed while following the docs for adding a schedule to a workflow. The cron expression in `deployment.md` isn't a valid quartz cron expression, this fixes that.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation Update (if none of the other choices apply)