### PR TITLE
Explicitly expose docker container attributes in NewCluster model

### DIFF
--- a/dbx/models/workflow/common/new_cluster.py
+++ b/dbx/models/workflow/common/new_cluster.py
@@ -19,6 +19,16 @@ class AutoScale(FlexibleModel):
         return values
 
 
+class ClusterDockerContainerBasicAuth(FlexibleModel):
+    username: str
+    password: str
+
+
+class ClusterDockerContainer(FlexibleModel):
+    url: str
+    basic_auth: Optional[ClusterDockerContainerBasicAuth]
+
+
 class AwsAttributes(FlexibleModel):
     first_on_demand: Optional[int]
     availability: Optional[str]
@@ -38,6 +48,7 @@ class NewCluster(FlexibleModel):
     num_workers: Optional[int]
     autoscale: Optional[AutoScale]
     instance_pool_name: Optional[str]
+    docker_image: Optional[ClusterDockerContainer]
     driver_instance_pool_name: Optional[str]
     driver_instance_pool_id: Optional[str]
     instance_pool_id: Optional[str]

--- a/docs/reference/deployment.md
+++ b/docs/reference/deployment.md
@@ -269,6 +269,8 @@ custom:
     instance_pool_id: "instance-pool://some-pool-name"
     driver_instance_pool_id: "instance-pool://some-pool-name"
     runtime_engine: STANDARD
+    docker_image:
+      url: databricksruntime/standard:latest
     init_scripts:
       - dbfs:
           destination: dbfs:/<enter your path>


### PR DESCRIPTION
## Proposed changes

Alters the `NewCluster` model to expose the configuration options for [clusters custom containers](https://docs.databricks.com/en/clusters/custom-containers.html).

Resolves #815 even though you can already specify such config options because of `NewCluster` being a *flexible model*.

## Types of changes

What types of changes does your code introduce to dbx?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation Update (if none of the other choices apply)

